### PR TITLE
refactor: extract shared canvas infrastructure from pattern editor dialogs

### DIFF
--- a/src/components/pattern-library/PatternDialogShell.tsx
+++ b/src/components/pattern-library/PatternDialogShell.tsx
@@ -1,0 +1,122 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface PatternDialogShellProps {
+  onClose: () => void;
+  onSave: () => void;
+  isSaving: boolean;
+  saveError: string | null;
+  isDemoPlaying: boolean;
+  demoError: string | null;
+  isDeviceConnected: boolean;
+  onStartDemo: () => void;
+  onStopDemo: () => void;
+  header: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Shared modal shell for pattern editor dialogs.
+ * Provides backdrop, close button, error display, and action row (Demo / Save / Close).
+ * Callers handle their own visibility — this component always renders when mounted.
+ */
+export function PatternDialogShell({
+  onClose,
+  onSave,
+  isSaving,
+  saveError,
+  isDemoPlaying,
+  demoError,
+  isDeviceConnected,
+  onStartDemo,
+  onStopDemo,
+  header,
+  children,
+}: PatternDialogShellProps) {
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
+      onClick={handleBackdropClick}
+    >
+      <div className="bg-zinc-900 border border-zinc-700 rounded-lg max-w-3xl w-full p-6 max-h-[90vh] overflow-y-auto shadow-2xl">
+        {/* Header row: caller-provided content + close button */}
+        <div className="flex items-start justify-between mb-4 gap-4">
+          <div className="flex-1 min-w-0">{header}</div>
+          <button
+            onClick={onClose}
+            className="text-zinc-400 hover:text-zinc-200 transition-colors shrink-0"
+            aria-label="Close"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Main content */}
+        {children}
+
+        {/* Error messages */}
+        {demoError && (
+          <div className="mb-4 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded text-red-400 text-sm">
+            {demoError}
+          </div>
+        )}
+        {saveError && (
+          <div className="mb-4 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded text-red-400 text-sm">
+            {saveError}
+          </div>
+        )}
+
+        {/* Action row */}
+        <div className="flex gap-3">
+          {isDeviceConnected && (
+            <button
+              onClick={isDemoPlaying ? onStopDemo : onStartDemo}
+              className={cn(
+                'px-4 py-2 rounded font-medium shadow-sm transition-colors',
+                isDemoPlaying
+                  ? 'bg-red-600 text-white hover:bg-red-700'
+                  : 'bg-purple-600 text-white hover:bg-purple-700',
+              )}
+            >
+              {isDemoPlaying ? 'Stop Demo' : 'Demo'}
+            </button>
+          )}
+
+          <button
+            onClick={onSave}
+            disabled={isSaving}
+            className="flex-1 px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors font-medium shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSaving ? 'Saving...' : 'Save'}
+          </button>
+
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded border border-zinc-600 text-zinc-200 hover:bg-zinc-800 transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pattern-library/PatternEditorDialog.tsx
+++ b/src/components/pattern-library/PatternEditorDialog.tsx
@@ -1,7 +1,19 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import type { FunscriptAction } from '@/types/funscript';
 import type { CustomPatternDefinition } from '@/types/patterns';
-import { cn } from '@/lib/utils';
+import { PatternDialogShell } from './PatternDialogShell';
+import { usePatternCanvas } from './usePatternCanvas';
+import {
+  CANVAS_HEIGHT,
+  DRAW_AREA_HEIGHT,
+  computeTimeRange,
+  dataToPixel,
+  pixelToData,
+  pointerToCanvasPixel,
+  pointDistance,
+  drawGrid,
+  drawTimeAxis,
+} from './patternCanvasUtils';
 
 interface PatternEditorDialogProps {
   pattern: CustomPatternDefinition | null;
@@ -20,9 +32,12 @@ interface PatternEditorDialogProps {
   isDeviceConnected: boolean;
 }
 
+const POINT_RADIUS = 6;
+const HIT_RADIUS = 8;
+
 /**
- * Full-screen modal dialog for editing custom patterns
- * Features draggable action points, duration/intensity controls, demo, and save
+ * Full-screen modal dialog for editing custom patterns.
+ * Features draggable action points, duration/intensity controls, demo, and save.
  */
 export function PatternEditorDialog({
   pattern,
@@ -40,35 +55,11 @@ export function PatternEditorDialog({
   saveError,
   isDeviceConnected,
 }: PatternEditorDialogProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
-  const [canvasWidth, setCanvasWidth] = useState(600);
+  const { canvasRef, containerRef, canvasWidth, draggedIndex, setDraggedIndex } =
+    usePatternCanvas();
 
-  // Canvas dimensions
-  const CANVAS_HEIGHT = 220;
-  const DRAW_AREA_HEIGHT = 190;
-  const LABEL_AREA_TOP = 195;
-  const POINT_RADIUS = 6;
-  const HIT_RADIUS = 8;
+  // --- Canvas drawing ---
 
-  // Resize canvas on container size change
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    const observer = new ResizeObserver((entries) => {
-      const width = entries[0].contentRect.width;
-      setCanvasWidth(width);
-    });
-
-    observer.observe(containerRef.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
-
-  // Draw pattern on canvas
   const drawPattern = (actions: FunscriptAction[]) => {
     const canvas = canvasRef.current;
     if (!canvas || actions.length === 0) return;
@@ -76,119 +67,52 @@ export function PatternEditorDialog({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    // Clear canvas
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawGrid(ctx, canvas.width);
 
-    // Draw grid lines
-    ctx.strokeStyle = '#3f3f46'; // zinc-700
-    ctx.lineWidth = 1;
-    ctx.setLineDash([4, 4]);
+    const tr = computeTimeRange(actions.map((a) => a.at));
 
-    // Horizontal grid lines at 0, 25, 50, 75, 100
-    [0, 25, 50, 75, 100].forEach((pos) => {
-      const y = DRAW_AREA_HEIGHT - (pos / 100) * DRAW_AREA_HEIGHT;
-      ctx.beginPath();
-      ctx.moveTo(0, y);
-      ctx.lineTo(canvas.width, y);
-      ctx.stroke();
-    });
-
-    ctx.setLineDash([]);
-
-    // Calculate time scale
-    const maxTime = Math.max(...actions.map((a) => a.at));
-    const minTime = Math.min(...actions.map((a) => a.at));
-    const timeRange = maxTime - minTime || 1;
-
-    // Draw pattern line
+    // Solid purple pattern line
     ctx.strokeStyle = '#8b5cf6'; // purple-500
     ctx.lineWidth = 3;
     ctx.beginPath();
 
     actions.forEach((action, i) => {
-      const x = ((action.at - minTime) / timeRange) * canvas.width;
-      const y = DRAW_AREA_HEIGHT - (action.pos / 100) * DRAW_AREA_HEIGHT;
-
-      if (i === 0) {
-        ctx.moveTo(x, y);
-      } else {
-        ctx.lineTo(x, y);
-      }
+      const { x, y } = dataToPixel(action.at, action.pos, tr, canvas.width);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
     });
 
     ctx.stroke();
 
-    // Draw action points as circles
+    // Action points as purple circles
     ctx.fillStyle = '#8b5cf6'; // purple-500
     actions.forEach((action) => {
-      const x = ((action.at - minTime) / timeRange) * canvas.width;
-      const y = DRAW_AREA_HEIGHT - (action.pos / 100) * DRAW_AREA_HEIGHT;
-
+      const { x, y } = dataToPixel(action.at, action.pos, tr, canvas.width);
       ctx.beginPath();
       ctx.arc(x, y, POINT_RADIUS, 0, Math.PI * 2);
       ctx.fill();
     });
 
-    // Draw time axis labels
-    ctx.fillStyle = '#a1a1aa'; // zinc-400
-    ctx.font = '11px monospace';
-    ctx.textBaseline = 'top';
-
-    // Draw evenly spaced time markers
-    const totalSeconds = timeRange / 1000;
-    const tickCount = Math.min(Math.max(3, Math.ceil(totalSeconds)), 8);
-
-    for (let i = 0; i <= tickCount; i++) {
-      const fraction = i / tickCount;
-      const x = fraction * canvas.width;
-      const timeAtTick = minTime + fraction * timeRange;
-      const label = (timeAtTick / 1000).toFixed(1) + 's';
-
-      // Align text: left for first, right for last, center for middle
-      if (i === 0) {
-        ctx.textAlign = 'left';
-      } else if (i === tickCount) {
-        ctx.textAlign = 'right';
-      } else {
-        ctx.textAlign = 'center';
-      }
-
-      ctx.fillText(label, x, LABEL_AREA_TOP);
-    }
+    drawTimeAxis(ctx, tr, canvas.width);
   };
 
-  // Redraw when pattern or canvas size changes
   useEffect(() => {
-    if (pattern && canvasRef.current) {
-      drawPattern(pattern.actions);
-    }
+    if (pattern) drawPattern(pattern.actions);
   }, [pattern, canvasWidth]);
 
-  // Handle pointer down - start drag
+  // --- Pointer handlers ---
+
   const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    if (!pattern || !canvasRef.current) return;
-
     const canvas = canvasRef.current;
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-    const x = (e.clientX - rect.left) * scaleX;
-    const y = (e.clientY - rect.top) * scaleY;
+    if (!pattern || !canvas) return;
 
-    // Hit test against all points
-    const actions = pattern.actions;
-    const maxTime = Math.max(...actions.map((a) => a.at));
-    const minTime = Math.min(...actions.map((a) => a.at));
-    const timeRange = maxTime - minTime || 1;
+    const { x, y } = pointerToCanvasPixel(e.clientX, e.clientY, canvas);
+    const tr = computeTimeRange(pattern.actions.map((a) => a.at));
 
-    for (let i = 0; i < actions.length; i++) {
-      const action = actions[i];
-      const px = ((action.at - minTime) / timeRange) * canvas.width;
-      const py = DRAW_AREA_HEIGHT - (action.pos / 100) * DRAW_AREA_HEIGHT;
-
-      const distance = Math.sqrt((x - px) ** 2 + (y - py) ** 2);
-
-      if (distance <= HIT_RADIUS) {
+    for (let i = 0; i < pattern.actions.length; i++) {
+      const pt = dataToPixel(pattern.actions[i].at, pattern.actions[i].pos, tr, canvas.width);
+      if (pointDistance(x, y, pt.x, pt.y) <= HIT_RADIUS) {
         setDraggedIndex(i);
         canvas.setPointerCapture(e.pointerId);
         break;
@@ -196,52 +120,26 @@ export function PatternEditorDialog({
     }
   };
 
-  // Handle pointer move - update dragged point
   const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    if (draggedIndex === null || !pattern || !canvasRef.current) return;
-
     const canvas = canvasRef.current;
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-    const x = (e.clientX - rect.left) * scaleX;
-    const y = (e.clientY - rect.top) * scaleY;
+    if (draggedIndex === null || !pattern || !canvas) return;
 
-    // Convert canvas coordinates to time/position
-    const actions = pattern.actions;
-    const maxTime = Math.max(...actions.map((a) => a.at));
-    const minTime = Math.min(...actions.map((a) => a.at));
-    const timeRange = maxTime - minTime || 1;
+    const { x, y } = pointerToCanvasPixel(e.clientX, e.clientY, canvas);
+    const tr = computeTimeRange(pattern.actions.map((a) => a.at));
+    const data = pixelToData(x, y, tr, canvas.width);
 
-    // Calculate new time (clamped to time range)
-    const newAt = Math.max(
-      minTime,
-      Math.min(maxTime, minTime + (x / canvas.width) * timeRange)
-    );
-
-    // Calculate new position (clamped to 0-100)
-    const newPos = Math.max(
-      0,
-      Math.min(100, 100 - (y / DRAW_AREA_HEIGHT) * 100)
-    );
-
-    // Update action
-    const updatedActions = actions.map((action, i) => {
+    const updatedActions = pattern.actions.map((action, i) => {
       if (i === draggedIndex) {
-        return { at: Math.round(newAt), pos: Math.round(newPos) };
+        return { at: Math.round(data.time), pos: Math.round(data.pos) };
       }
       return action;
     });
 
-    // Sort by time to maintain order
     updatedActions.sort((a, b) => a.at - b.at);
-
-    // Update and redraw
     onActionsChange(updatedActions);
     drawPattern(updatedActions);
   };
 
-  // Handle pointer up - end drag
   const handlePointerUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
     if (draggedIndex !== null && canvasRef.current) {
       canvasRef.current.releasePointerCapture(e.pointerId);
@@ -249,164 +147,82 @@ export function PatternEditorDialog({
     }
   };
 
-  // Handle duration change
   const handleDurationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseFloat(e.target.value);
-    if (!isNaN(value)) {
-      onDurationChange(value);
-    }
-  };
-
-  // Handle backdrop click
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
+    if (!isNaN(value)) onDurationChange(value);
   };
 
   if (!isOpen || !pattern) return null;
 
   return (
-    <div
-      className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
-      onClick={handleBackdropClick}
+    <PatternDialogShell
+      onClose={onClose}
+      onSave={onSave}
+      isSaving={isSaving}
+      saveError={saveError}
+      isDemoPlaying={isDemoPlaying}
+      demoError={demoError}
+      isDeviceConnected={isDeviceConnected}
+      onStartDemo={onStartDemo}
+      onStopDemo={onStopDemo}
+      header={
+        <h2 className="text-xl font-semibold text-foreground">{pattern.name}</h2>
+      }
     >
-      <div className="bg-zinc-900 border border-zinc-700 rounded-lg max-w-3xl w-full p-6 max-h-[90vh] overflow-y-auto shadow-2xl">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-xl font-semibold text-foreground">
-            {pattern.name}
-          </h2>
-          <button
-            onClick={onClose}
-            className="text-zinc-400 hover:text-zinc-200 transition-colors"
-            aria-label="Close"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
+      {/* Canvas */}
+      <div ref={containerRef} className="mb-4">
+        <canvas
+          ref={canvasRef}
+          width={canvasWidth}
+          height={CANVAS_HEIGHT}
+          className="w-full h-auto rounded border border-zinc-700 bg-zinc-950 cursor-crosshair"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          style={{ touchAction: 'none' }}
+        />
+      </div>
 
-        {/* Canvas area */}
-        <div ref={containerRef} className="mb-4">
-          <canvas
-            ref={canvasRef}
-            width={canvasWidth}
-            height={CANVAS_HEIGHT}
-            className="w-full h-auto rounded border border-zinc-700 bg-zinc-950 cursor-crosshair"
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
-            style={{ touchAction: 'none' }}
+      {/* Controls row */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">Duration (s)</label>
+          <input
+            type="number"
+            step="0.1"
+            min="0.5"
+            max="300"
+            value={(pattern.durationMs / 1000).toFixed(1)}
+            onChange={handleDurationChange}
+            className="w-full px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
           />
         </div>
 
-        {/* Controls row */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
-          {/* Duration input */}
-          <div>
-            <label className="text-xs text-muted-foreground block mb-1">
-              Duration (s)
-            </label>
-            <input
-              type="number"
-              step="0.1"
-              min="0.5"
-              max="300"
-              value={(pattern.durationMs / 1000).toFixed(1)}
-              onChange={handleDurationChange}
-              className="w-full px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
-            />
-          </div>
-
-          {/* Intensity buttons */}
-          <div>
-            <label className="text-xs text-muted-foreground block mb-1">
-              Intensity
-            </label>
-            <div className="flex gap-2">
-              <button
-                onClick={() => onIntensityChange(-10)}
-                className="flex-1 px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white hover:bg-zinc-700 transition-colors"
-              >
-                - Intensity
-              </button>
-              <button
-                onClick={() => onIntensityChange(10)}
-                className="flex-1 px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white hover:bg-zinc-700 transition-colors"
-              >
-                + Intensity
-              </button>
-            </div>
-          </div>
-
-          {/* Actions count (read-only) */}
-          <div>
-            <label className="text-xs text-muted-foreground block mb-1">
-              Action Points
-            </label>
-            <div className="px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white">
-              {pattern.actions.length}
-            </div>
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">Intensity</label>
+          <div className="flex gap-2">
+            <button
+              onClick={() => onIntensityChange(-10)}
+              className="flex-1 px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white hover:bg-zinc-700 transition-colors"
+            >
+              - Intensity
+            </button>
+            <button
+              onClick={() => onIntensityChange(10)}
+              className="flex-1 px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white hover:bg-zinc-700 transition-colors"
+            >
+              + Intensity
+            </button>
           </div>
         </div>
 
-        {/* Error messages */}
-        {demoError && (
-          <div className="mb-4 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded text-red-400 text-sm">
-            {demoError}
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">Action Points</label>
+          <div className="px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white">
+            {pattern.actions.length}
           </div>
-        )}
-        {saveError && (
-          <div className="mb-4 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded text-red-400 text-sm">
-            {saveError}
-          </div>
-        )}
-
-        {/* Action row */}
-        <div className="flex gap-3">
-          {isDeviceConnected && (
-            <button
-              onClick={isDemoPlaying ? onStopDemo : onStartDemo}
-              className={cn(
-                'px-4 py-2 rounded font-medium shadow-sm transition-colors',
-                isDemoPlaying
-                  ? 'bg-red-600 text-white hover:bg-red-700'
-                  : 'bg-purple-600 text-white hover:bg-purple-700'
-              )}
-            >
-              {isDemoPlaying ? 'Stop Demo' : 'Demo'}
-            </button>
-          )}
-
-          <button
-            onClick={onSave}
-            disabled={isSaving}
-            className="flex-1 px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors font-medium shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isSaving ? 'Saving...' : 'Save'}
-          </button>
-
-          <button
-            onClick={onClose}
-            className="px-4 py-2 rounded border border-zinc-600 text-zinc-200 hover:bg-zinc-800 transition-colors"
-          >
-            Close
-          </button>
         </div>
       </div>
-    </div>
+    </PatternDialogShell>
   );
 }

--- a/src/components/pattern-library/WaypointBuilderDialog.tsx
+++ b/src/components/pattern-library/WaypointBuilderDialog.tsx
@@ -1,10 +1,21 @@
-import { useEffect, useRef, useState, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { WaypointDefinition, InterpolationType } from '@/types/patterns';
 import type { FunscriptAction } from '@/types/funscript';
-import { cn } from '@/lib/utils';
+import { PatternDialogShell } from './PatternDialogShell';
+import { usePatternCanvas } from './usePatternCanvas';
+import {
+  CANVAS_HEIGHT,
+  DRAW_AREA_HEIGHT,
+  computeTimeRange,
+  dataToPixel,
+  pixelToData,
+  pointerToCanvasPixel,
+  pointDistance,
+  drawGrid,
+  drawTimeAxis,
+} from './patternCanvasUtils';
 
 interface WaypointBuilderDialogProps {
-  // State from useWaypointBuilder hook
   waypoints: WaypointDefinition[];
   patternName: string;
   selectedIndex: number | null;
@@ -17,8 +28,6 @@ interface WaypointBuilderDialogProps {
   canRemoveWaypoint: boolean;
   totalDurationMs: number;
   isDeviceConnected: boolean;
-
-  // Methods from useWaypointBuilder hook
   onClose: () => void;
   onPatternNameChange: (name: string) => void;
   onAddWaypoint: (pos: number, timeMs: number) => void;
@@ -31,9 +40,13 @@ interface WaypointBuilderDialogProps {
   onSave: () => void;
 }
 
+const WAYPOINT_RADIUS = 8;
+const HIT_RADIUS = 12;
+
 /**
- * Full-screen modal dialog for waypoint-based pattern creation
- * Features interactive canvas with draggable diamond waypoints, interpolation controls, demo, and save
+ * Full-screen modal dialog for waypoint-based pattern creation.
+ * Features interactive canvas with draggable diamond waypoints,
+ * interpolation controls, demo, and save.
  */
 export function WaypointBuilderDialog({
   waypoints,
@@ -59,38 +72,13 @@ export function WaypointBuilderDialog({
   onStopDemo,
   onSave,
 }: WaypointBuilderDialogProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
-  const [canvasWidth, setCanvasWidth] = useState(600);
+  const { canvasRef, containerRef, canvasWidth, draggedIndex, setDraggedIndex } =
+    usePatternCanvas();
 
-  // Canvas dimensions
-  const CANVAS_HEIGHT = 220;
-  const DRAW_AREA_HEIGHT = 190;
-  const LABEL_AREA_TOP = 195;
-  const WAYPOINT_RADIUS = 8; // Diamond radius (rotated square)
-  const HIT_RADIUS = 12; // Hit test radius
-
-  // Memoize generated actions to avoid regenerating on every render
   const generatedActions = useMemo(() => onGenerateActions(), [waypoints, onGenerateActions]);
 
-  // Resize canvas on container size change
-  useEffect(() => {
-    if (!containerRef.current) return;
+  // --- Canvas drawing ---
 
-    const observer = new ResizeObserver((entries) => {
-      const width = entries[0].contentRect.width;
-      setCanvasWidth(width);
-    });
-
-    observer.observe(containerRef.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
-
-  // Draw pattern on canvas
   const drawPattern = () => {
     const canvas = canvasRef.current;
     if (!canvas || waypoints.length === 0) return;
@@ -98,31 +86,12 @@ export function WaypointBuilderDialog({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    // Clear canvas
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawGrid(ctx, canvas.width);
 
-    // Draw grid lines
-    ctx.strokeStyle = '#3f3f46'; // zinc-700
-    ctx.lineWidth = 1;
-    ctx.setLineDash([4, 4]);
+    const tr = computeTimeRange(waypoints.map((w) => w.timeMs));
 
-    // Horizontal grid lines at 0, 25, 50, 75, 100
-    [0, 25, 50, 75, 100].forEach((pos) => {
-      const y = DRAW_AREA_HEIGHT - (pos / 100) * DRAW_AREA_HEIGHT;
-      ctx.beginPath();
-      ctx.moveTo(0, y);
-      ctx.lineTo(canvas.width, y);
-      ctx.stroke();
-    });
-
-    ctx.setLineDash([]);
-
-    // Calculate time scale
-    const maxTime = Math.max(...waypoints.map((w) => w.timeMs));
-    const minTime = Math.min(...waypoints.map((w) => w.timeMs));
-    const timeRange = maxTime - minTime || 1;
-
-    // Draw generated actions as dashed purple line
+    // Generated actions as dashed purple line
     if (generatedActions.length > 0) {
       ctx.strokeStyle = '#a78bfa'; // purple-400
       ctx.lineWidth = 2;
@@ -130,44 +99,40 @@ export function WaypointBuilderDialog({
       ctx.beginPath();
 
       generatedActions.forEach((action, i) => {
-        const x = ((action.at - minTime) / timeRange) * canvas.width;
-        const y = DRAW_AREA_HEIGHT - (action.pos / 100) * DRAW_AREA_HEIGHT;
-
-        if (i === 0) {
-          ctx.moveTo(x, y);
-        } else {
-          ctx.lineTo(x, y);
-        }
+        const { x, y } = dataToPixel(action.at, action.pos, tr, canvas.width);
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
       });
 
       ctx.stroke();
       ctx.setLineDash([]);
     }
 
-    // Draw waypoints as filled amber diamonds (rotated squares)
+    // Waypoints as amber diamonds
     waypoints.forEach((waypoint, index) => {
-      const x = ((waypoint.timeMs - minTime) / timeRange) * canvas.width;
-      const y = DRAW_AREA_HEIGHT - (waypoint.pos / 100) * DRAW_AREA_HEIGHT;
+      const { x, y } = dataToPixel(waypoint.timeMs, waypoint.pos, tr, canvas.width);
 
-      // Draw diamond (rotated 45 degrees square)
       ctx.save();
       ctx.translate(x, y);
       ctx.rotate(Math.PI / 4);
 
-      // Fill diamond
       ctx.fillStyle = '#fbbf24'; // amber-400
       ctx.fillRect(-WAYPOINT_RADIUS, -WAYPOINT_RADIUS, WAYPOINT_RADIUS * 2, WAYPOINT_RADIUS * 2);
 
-      // Draw selection ring if selected
       if (index === selectedIndex) {
         ctx.strokeStyle = '#22d3ee'; // cyan-400
         ctx.lineWidth = 2;
-        ctx.strokeRect(-WAYPOINT_RADIUS - 1, -WAYPOINT_RADIUS - 1, WAYPOINT_RADIUS * 2 + 2, WAYPOINT_RADIUS * 2 + 2);
+        ctx.strokeRect(
+          -WAYPOINT_RADIUS - 1,
+          -WAYPOINT_RADIUS - 1,
+          WAYPOINT_RADIUS * 2 + 2,
+          WAYPOINT_RADIUS * 2 + 2,
+        );
       }
 
       ctx.restore();
 
-      // Draw index label (1-based) centered in diamond
+      // Index label centered in diamond
       ctx.fillStyle = '#000000';
       ctx.font = 'bold 10px sans-serif';
       ctx.textAlign = 'center';
@@ -175,67 +140,27 @@ export function WaypointBuilderDialog({
       ctx.fillText(String(index + 1), x, y);
     });
 
-    // Draw time axis labels
-    ctx.fillStyle = '#a1a1aa'; // zinc-400
-    ctx.font = '11px monospace';
-    ctx.textBaseline = 'top';
-
-    // Draw evenly spaced time markers
-    const totalSeconds = timeRange / 1000;
-    const tickCount = Math.min(Math.max(3, Math.ceil(totalSeconds)), 8);
-
-    for (let i = 0; i <= tickCount; i++) {
-      const fraction = i / tickCount;
-      const x = fraction * canvas.width;
-      const timeAtTick = minTime + fraction * timeRange;
-      const label = (timeAtTick / 1000).toFixed(1) + 's';
-
-      // Align text: left for first, right for last, center for middle
-      if (i === 0) {
-        ctx.textAlign = 'left';
-      } else if (i === tickCount) {
-        ctx.textAlign = 'right';
-      } else {
-        ctx.textAlign = 'center';
-      }
-
-      ctx.fillText(label, x, LABEL_AREA_TOP);
-    }
+    drawTimeAxis(ctx, tr, canvas.width);
   };
 
-  // Redraw when waypoints or canvas size changes
   useEffect(() => {
-    if (isOpen) {
-      drawPattern();
-    }
+    if (isOpen) drawPattern();
   }, [waypoints, selectedIndex, generatedActions, canvasWidth, isOpen]);
 
-  // Handle pointer down - select or start drag
+  // --- Pointer handlers ---
+
   const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    if (!canvasRef.current) return;
-
     const canvas = canvasRef.current;
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-    const x = (e.clientX - rect.left) * scaleX;
-    const y = (e.clientY - rect.top) * scaleY;
+    if (!canvas) return;
 
-    // Hit test against all waypoints
-    const maxTime = Math.max(...waypoints.map((w) => w.timeMs));
-    const minTime = Math.min(...waypoints.map((w) => w.timeMs));
-    const timeRange = maxTime - minTime || 1;
+    const { x, y } = pointerToCanvasPixel(e.clientX, e.clientY, canvas);
+    const tr = computeTimeRange(waypoints.map((w) => w.timeMs));
 
     let hitWaypoint = false;
 
     for (let i = 0; i < waypoints.length; i++) {
-      const waypoint = waypoints[i];
-      const wx = ((waypoint.timeMs - minTime) / timeRange) * canvas.width;
-      const wy = DRAW_AREA_HEIGHT - (waypoint.pos / 100) * DRAW_AREA_HEIGHT;
-
-      const distance = Math.sqrt((x - wx) ** 2 + (y - wy) ** 2);
-
-      if (distance <= HIT_RADIUS) {
+      const pt = dataToPixel(waypoints[i].timeMs, waypoints[i].pos, tr, canvas.width);
+      if (pointDistance(x, y, pt.x, pt.y) <= HIT_RADIUS) {
         onSelectWaypoint(i);
         setDraggedIndex(i);
         canvas.setPointerCapture(e.pointerId);
@@ -244,47 +169,23 @@ export function WaypointBuilderDialog({
       }
     }
 
-    // If no waypoint hit, add a new one if possible
     if (!hitWaypoint && canAddWaypoint && y <= DRAW_AREA_HEIGHT) {
-      const newTimeMs = minTime + (x / canvas.width) * timeRange;
-      const newPos = 100 - (y / DRAW_AREA_HEIGHT) * 100;
-      onAddWaypoint(newPos, newTimeMs);
+      const data = pixelToData(x, y, tr, canvas.width);
+      onAddWaypoint(data.pos, data.time);
     }
   };
 
-  // Handle pointer move - update dragged waypoint
   const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    if (draggedIndex === null || !canvasRef.current) return;
-
     const canvas = canvasRef.current;
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-    const x = (e.clientX - rect.left) * scaleX;
-    const y = (e.clientY - rect.top) * scaleY;
+    if (draggedIndex === null || !canvas) return;
 
-    // Calculate time scale
-    const maxTime = Math.max(...waypoints.map((w) => w.timeMs));
-    const minTime = Math.min(...waypoints.map((w) => w.timeMs));
-    const timeRange = maxTime - minTime || 1;
+    const { x, y } = pointerToCanvasPixel(e.clientX, e.clientY, canvas);
+    const tr = computeTimeRange(waypoints.map((w) => w.timeMs));
+    const data = pixelToData(x, y, tr, canvas.width);
 
-    // Calculate new time (clamped to time range)
-    const newTimeMs = Math.max(
-      minTime,
-      Math.min(maxTime, minTime + (x / canvas.width) * timeRange)
-    );
-
-    // Calculate new position (clamped to 0-100)
-    const newPos = Math.max(
-      0,
-      Math.min(100, 100 - (y / DRAW_AREA_HEIGHT) * 100)
-    );
-
-    // Update waypoint
-    onUpdateWaypoint(draggedIndex, { pos: newPos, timeMs: newTimeMs });
+    onUpdateWaypoint(draggedIndex, { pos: data.pos, timeMs: data.time });
   };
 
-  // Handle pointer up - end drag
   const handlePointerUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
     if (draggedIndex !== null && canvasRef.current) {
       canvasRef.current.releasePointerCapture(e.pointerId);
@@ -292,17 +193,10 @@ export function WaypointBuilderDialog({
     }
   };
 
-  // Handle backdrop click
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
+  // --- Save handler (closes dialog after save) ---
 
-  // Handle save
   const handleSave = async () => {
     await onSave();
-    // Close dialog after successful save
     onClose();
   };
 
@@ -311,163 +205,94 @@ export function WaypointBuilderDialog({
   const selectedWaypoint = selectedIndex !== null ? waypoints[selectedIndex] : null;
 
   return (
-    <div
-      className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
-      onClick={handleBackdropClick}
-    >
-      <div className="bg-zinc-900 border border-zinc-700 rounded-lg max-w-3xl w-full p-6 max-h-[90vh] overflow-y-auto shadow-2xl">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-4 gap-4">
-          <div className="flex-1">
-            <label className="text-xs text-muted-foreground block mb-1">
-              Pattern Name
-            </label>
-            <input
-              type="text"
-              value={patternName}
-              onChange={(e) => onPatternNameChange(e.target.value)}
-              className="w-full px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
-            />
-          </div>
-          <button
-            onClick={onClose}
-            className="text-zinc-400 hover:text-zinc-200 transition-colors mt-5"
-            aria-label="Close"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-
-        {/* Canvas area */}
-        <div ref={containerRef} className="mb-4">
-          <canvas
-            ref={canvasRef}
-            width={canvasWidth}
-            height={CANVAS_HEIGHT}
-            className="w-full h-auto rounded border border-zinc-700 bg-zinc-950 cursor-crosshair"
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
-            style={{ touchAction: 'none' }}
+    <PatternDialogShell
+      onClose={onClose}
+      onSave={handleSave}
+      isSaving={isSaving}
+      saveError={saveError}
+      isDemoPlaying={isDemoPlaying}
+      demoError={demoError}
+      isDeviceConnected={isDeviceConnected}
+      onStartDemo={onStartDemo}
+      onStopDemo={onStopDemo}
+      header={
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">Pattern Name</label>
+          <input
+            type="text"
+            value={patternName}
+            onChange={(e) => onPatternNameChange(e.target.value)}
+            className="w-full px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
           />
         </div>
+      }
+    >
+      {/* Canvas */}
+      <div ref={containerRef} className="mb-4">
+        <canvas
+          ref={canvasRef}
+          width={canvasWidth}
+          height={CANVAS_HEIGHT}
+          className="w-full h-auto rounded border border-zinc-700 bg-zinc-950 cursor-crosshair"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          style={{ touchAction: 'none' }}
+        />
+      </div>
 
-        {/* Selected waypoint controls */}
-        {selectedWaypoint !== null && selectedIndex !== null && (
-          <div className="mb-4 p-4 rounded bg-zinc-800 border border-zinc-700">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {/* Waypoint info */}
-              <div>
-                <label className="text-xs text-muted-foreground block mb-1">
-                  Point {selectedIndex + 1}
-                </label>
-                <div className="px-3 py-2 rounded bg-zinc-900 border border-zinc-700 text-white text-sm">
-                  pos={selectedWaypoint.pos}, time={selectedWaypoint.timeMs}ms
-                </div>
-              </div>
-
-              {/* Interpolation dropdown */}
-              <div>
-                <label className="text-xs text-muted-foreground block mb-1">
-                  Interpolation
-                </label>
-                <select
-                  value={selectedWaypoint.interpolation}
-                  onChange={(e) =>
-                    onUpdateWaypoint(selectedIndex, {
-                      interpolation: e.target.value as InterpolationType,
-                    })
-                  }
-                  disabled={selectedIndex === 0}
-                  title={
-                    selectedIndex === 0
-                      ? 'First waypoint has no preceding segment'
-                      : undefined
-                  }
-                  className="w-full px-3 py-2 rounded bg-zinc-900 border border-zinc-700 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <option value="linear">Linear</option>
-                  <option value="easeIn">Ease In</option>
-                  <option value="easeOut">Ease Out</option>
-                  <option value="easeInOut">Ease In/Out</option>
-                  <option value="step">Step</option>
-                </select>
+      {/* Selected waypoint controls */}
+      {selectedWaypoint !== null && selectedIndex !== null && (
+        <div className="mb-4 p-4 rounded bg-zinc-800 border border-zinc-700">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="text-xs text-muted-foreground block mb-1">
+                Point {selectedIndex + 1}
+              </label>
+              <div className="px-3 py-2 rounded bg-zinc-900 border border-zinc-700 text-white text-sm">
+                pos={selectedWaypoint.pos}, time={selectedWaypoint.timeMs}ms
               </div>
             </div>
 
-            {/* Remove button */}
-            <button
-              onClick={() => onRemoveWaypoint(selectedIndex)}
-              disabled={!canRemoveWaypoint}
-              className="mt-3 px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Remove Point
-            </button>
+            <div>
+              <label className="text-xs text-muted-foreground block mb-1">Interpolation</label>
+              <select
+                value={selectedWaypoint.interpolation}
+                onChange={(e) =>
+                  onUpdateWaypoint(selectedIndex, {
+                    interpolation: e.target.value as InterpolationType,
+                  })
+                }
+                disabled={selectedIndex === 0}
+                title={
+                  selectedIndex === 0 ? 'First waypoint has no preceding segment' : undefined
+                }
+                className="w-full px-3 py-2 rounded bg-zinc-900 border border-zinc-700 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <option value="linear">Linear</option>
+                <option value="easeIn">Ease In</option>
+                <option value="easeOut">Ease Out</option>
+                <option value="easeInOut">Ease In/Out</option>
+                <option value="step">Step</option>
+              </select>
+            </div>
           </div>
-        )}
-
-        {/* Info bar */}
-        <div className="mb-4 px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-sm text-zinc-300">
-          {waypoints.length} waypoints | Duration: {(totalDurationMs / 1000).toFixed(1)}s | {generatedActions.length} action points
-        </div>
-
-        {/* Error messages */}
-        {demoError && (
-          <div className="mb-4 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded text-red-400 text-sm">
-            {demoError}
-          </div>
-        )}
-        {saveError && (
-          <div className="mb-4 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded text-red-400 text-sm">
-            {saveError}
-          </div>
-        )}
-
-        {/* Action row */}
-        <div className="flex gap-3">
-          {isDeviceConnected && (
-            <button
-              onClick={isDemoPlaying ? onStopDemo : onStartDemo}
-              className={cn(
-                'px-4 py-2 rounded font-medium shadow-sm transition-colors',
-                isDemoPlaying
-                  ? 'bg-red-600 text-white hover:bg-red-700'
-                  : 'bg-purple-600 text-white hover:bg-purple-700'
-              )}
-            >
-              {isDemoPlaying ? 'Stop Demo' : 'Demo'}
-            </button>
-          )}
 
           <button
-            onClick={handleSave}
-            disabled={isSaving}
-            className="flex-1 px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors font-medium shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={() => onRemoveWaypoint(selectedIndex)}
+            disabled={!canRemoveWaypoint}
+            className="mt-3 px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isSaving ? 'Saving...' : 'Save'}
-          </button>
-
-          <button
-            onClick={onClose}
-            className="px-4 py-2 rounded border border-zinc-600 text-zinc-200 hover:bg-zinc-800 transition-colors"
-          >
-            Close
+            Remove Point
           </button>
         </div>
+      )}
+
+      {/* Info bar */}
+      <div className="mb-4 px-3 py-2 rounded bg-zinc-800 border border-zinc-700 text-sm text-zinc-300">
+        {waypoints.length} waypoints | Duration: {(totalDurationMs / 1000).toFixed(1)}s |{' '}
+        {generatedActions.length} action points
       </div>
-    </div>
+    </PatternDialogShell>
   );
 }

--- a/src/components/pattern-library/patternCanvasUtils.ts
+++ b/src/components/pattern-library/patternCanvasUtils.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared canvas drawing and coordinate utilities for pattern editor dialogs.
+ * Pure functions — no React dependency.
+ */
+
+/** Canvas layout constants */
+export const CANVAS_HEIGHT = 220;
+export const DRAW_AREA_HEIGHT = 190;
+export const LABEL_AREA_TOP = 195;
+
+/** Min/max/range computed from a set of time values */
+export interface TimeRange {
+  minTime: number;
+  maxTime: number;
+  range: number;
+}
+
+/**
+ * Compute min, max, and range from an array of time values.
+ * Range is at least 1 to prevent division by zero.
+ */
+export function computeTimeRange(times: number[]): TimeRange {
+  const minTime = Math.min(...times);
+  const maxTime = Math.max(...times);
+  return { minTime, maxTime, range: maxTime - minTime || 1 };
+}
+
+/**
+ * Convert a data-space (time, position) pair to canvas pixel coordinates.
+ */
+export function dataToPixel(
+  time: number,
+  pos: number,
+  tr: TimeRange,
+  canvasWidth: number,
+): { x: number; y: number } {
+  return {
+    x: ((time - tr.minTime) / tr.range) * canvasWidth,
+    y: DRAW_AREA_HEIGHT - (pos / 100) * DRAW_AREA_HEIGHT,
+  };
+}
+
+/**
+ * Convert canvas pixel coordinates to data-space (time, position).
+ * Time is clamped to the given range; position is clamped to 0–100.
+ */
+export function pixelToData(
+  px: number,
+  py: number,
+  tr: TimeRange,
+  canvasWidth: number,
+): { time: number; pos: number } {
+  const time = Math.max(
+    tr.minTime,
+    Math.min(tr.maxTime, tr.minTime + (px / canvasWidth) * tr.range),
+  );
+  const pos = Math.max(0, Math.min(100, 100 - (py / DRAW_AREA_HEIGHT) * 100));
+  return { time, pos };
+}
+
+/**
+ * Convert pointer event client coordinates to canvas pixel coordinates,
+ * accounting for CSS scaling (logical canvas width vs displayed width).
+ */
+export function pointerToCanvasPixel(
+  clientX: number,
+  clientY: number,
+  canvas: HTMLCanvasElement,
+): { x: number; y: number } {
+  const rect = canvas.getBoundingClientRect();
+  return {
+    x: (clientX - rect.left) * (canvas.width / rect.width),
+    y: (clientY - rect.top) * (canvas.height / rect.height),
+  };
+}
+
+/**
+ * Draw dashed horizontal grid lines at 0%, 25%, 50%, 75%, 100% positions.
+ */
+export function drawGrid(ctx: CanvasRenderingContext2D, canvasWidth: number): void {
+  ctx.strokeStyle = '#3f3f46'; // zinc-700
+  ctx.lineWidth = 1;
+  ctx.setLineDash([4, 4]);
+
+  [0, 25, 50, 75, 100].forEach((pos) => {
+    const y = DRAW_AREA_HEIGHT - (pos / 100) * DRAW_AREA_HEIGHT;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(canvasWidth, y);
+    ctx.stroke();
+  });
+
+  ctx.setLineDash([]);
+}
+
+/**
+ * Draw evenly-spaced time axis labels below the drawing area.
+ */
+export function drawTimeAxis(
+  ctx: CanvasRenderingContext2D,
+  tr: TimeRange,
+  canvasWidth: number,
+): void {
+  ctx.fillStyle = '#a1a1aa'; // zinc-400
+  ctx.font = '11px monospace';
+  ctx.textBaseline = 'top';
+
+  const totalSeconds = tr.range / 1000;
+  const tickCount = Math.min(Math.max(3, Math.ceil(totalSeconds)), 8);
+
+  for (let i = 0; i <= tickCount; i++) {
+    const fraction = i / tickCount;
+    const x = fraction * canvasWidth;
+    const label = ((tr.minTime + fraction * tr.range) / 1000).toFixed(1) + 's';
+
+    if (i === 0) {
+      ctx.textAlign = 'left';
+    } else if (i === tickCount) {
+      ctx.textAlign = 'right';
+    } else {
+      ctx.textAlign = 'center';
+    }
+
+    ctx.fillText(label, x, LABEL_AREA_TOP);
+  }
+}
+
+/**
+ * Euclidean distance between two points.
+ */
+export function pointDistance(x1: number, y1: number, x2: number, y2: number): number {
+  return Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
+}

--- a/src/components/pattern-library/usePatternCanvas.ts
+++ b/src/components/pattern-library/usePatternCanvas.ts
@@ -1,0 +1,25 @@
+import { useRef, useState, useEffect } from 'react';
+
+/**
+ * Hook managing shared canvas infrastructure for pattern editor dialogs:
+ * resize observer tracking container width, and drag state.
+ */
+export function usePatternCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [canvasWidth, setCanvasWidth] = useState(600);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const observer = new ResizeObserver((entries) => {
+      setCanvasWidth(entries[0].contentRect.width);
+    });
+
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return { canvasRef, containerRef, canvasWidth, draggedIndex, setDraggedIndex };
+}


### PR DESCRIPTION
## Summary
- Extracted duplicated modal chrome, canvas drawing utilities, resize observer, and coordinate math from `WaypointBuilderDialog` and `PatternEditorDialog` into 3 reusable modules:
  - **`PatternDialogShell`** — shared modal backdrop, close button, error display, and action row (Demo/Save/Close)
  - **`patternCanvasUtils`** — pure functions for grid drawing, time axis labels, coordinate conversion, and hit testing
  - **`usePatternCanvas`** — hook for ResizeObserver-based canvas width tracking and drag state
- `WaypointBuilderDialog`: 473 → 298 lines (37% reduction)
- `PatternEditorDialog`: 412 → 228 lines (45% reduction)
- Zero duplicated code between the two dialogs

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] All 35 existing tests pass (`npx vitest run`)
- [ ] Manual: open Waypoint Builder dialog, verify canvas drawing, waypoint drag, interpolation controls, save+close behavior
- [ ] Manual: open Pattern Editor dialog, verify canvas drawing, point drag, duration/intensity controls, save behavior
- [ ] Manual: verify Demo button works on both dialogs when device is connected