### PR TITLE
refactor: extract getErrorMessage utility to DRY up error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { PatternLibraryPage } from '@/components/pages/PatternLibraryPage';
 import { LibraryPage } from '@/components/pages/LibraryPage';
 import { PlaylistPage } from '@/components/pages/PlaylistPage';
 import { PlaylistControls } from '@/components/playlist/PlaylistControls';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 import { Timeline } from '@/components/timeline/Timeline';
 import { useVideoFile } from '@/hooks/useVideoFile';
 import { useFunscriptFile } from '@/hooks/useFunscriptFile';
@@ -393,7 +394,7 @@ function App() {
         addLog('info', `Loaded from library: ${item.funscriptName || 'Unnamed'}`);
       }
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to load library item';
+      const errorMessage = getErrorMessage(err, 'Failed to load library item');
       addLog('error', errorMessage);
     }
   };

--- a/src/components/pattern-library/PatternDetailDialog.tsx
+++ b/src/components/pattern-library/PatternDetailDialog.tsx
@@ -4,6 +4,7 @@ import type { PatternDefinition } from '@/types/patterns';
 import { getPatternDirection } from '@/lib/patternDefinitions';
 import { createSmoothTransition } from '@/lib/patternInsertion';
 import { cn } from '@/lib/utils';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 
 interface PatternDetailDialogProps {
   pattern: PatternDefinition | null;
@@ -158,7 +159,7 @@ export function PatternDetailDialog({
 
       setIsDemoPlaying(true);
     } catch (err) {
-      setDemoError(err instanceof Error ? err.message : 'Failed to start demo');
+      setDemoError(getErrorMessage(err, 'Failed to start demo'));
     }
   }, [ultra, pattern]);
 
@@ -170,7 +171,7 @@ export function PatternDetailDialog({
       setIsDemoPlaying(false);
       setDemoError(null);
     } catch (err) {
-      setDemoError(err instanceof Error ? err.message : 'Failed to stop demo');
+      setDemoError(getErrorMessage(err, 'Failed to stop demo'));
     }
   }, [ultra]);
 

--- a/src/hooks/useEmbedPlayback.ts
+++ b/src/hooks/useEmbedPlayback.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, type RefObject } from 'react';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 
 interface UseEmbedPlaybackReturn {
   isPlaying: boolean;
@@ -77,7 +78,7 @@ export function useEmbedPlayback({
   };
 
   const onError = (e: unknown) => {
-    const errorMessage = e instanceof Error ? e.message : 'Failed to load embedded video';
+    const errorMessage = getErrorMessage(e, 'Failed to load embedded video');
     setError(errorMessage);
   };
 

--- a/src/hooks/useFunscriptFile.ts
+++ b/src/hooks/useFunscriptFile.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { parseFunscriptFile, type ZodFunscript } from '@/lib/schemas';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 
 interface UseFunscriptFileReturn {
   funscriptFile: File | null;
@@ -27,7 +28,7 @@ export function useFunscriptFile(): UseFunscriptFileReturn {
       setFunscriptFile(file);
       setFunscriptData(data);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to load funscript';
+      const errorMessage = getErrorMessage(err, 'Failed to load funscript');
       setError(errorMessage);
       setFunscriptFile(null);
       setFunscriptData(null);

--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -5,6 +5,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { libraryApi } from '@/lib/apiClient';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 import type { LibraryItem } from '../../server/types/shared';
 
 export type LibraryFilter = 'all' | 'has-video' | 'has-funscript';
@@ -49,7 +50,7 @@ export function useLibrary(): UseLibraryReturn {
       
       setRawItems(results);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch library items';
+      const errorMessage = getErrorMessage(err, 'Failed to fetch library items');
       setError(errorMessage);
       setRawItems([]);
     } finally {
@@ -117,7 +118,7 @@ export function useLibrary(): UseLibraryReturn {
       await libraryApi.deleteItem(id);
       await fetchItems(searchQuery);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to delete item';
+      const errorMessage = getErrorMessage(err, 'Failed to delete item');
       setError(errorMessage);
       throw err;
     }

--- a/src/hooks/useManualControl.ts
+++ b/src/hooks/useManualControl.ts
@@ -3,6 +3,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import type { Ultra } from '@xsense/autoblow-sdk';
 import type { PatternType, ManualControlParams } from '@/types/device';
 import { generatePatternFunscript } from '@/lib/funscriptGenerator';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 
 export interface UseManualControlReturn {
   isRunning: boolean;
@@ -44,7 +45,7 @@ export function useManualControl(ultra: Ultra | null): UseManualControlReturn {
       try {
         await ultra.oscillateSet(speed, minY, maxY);
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to update oscillation parameters');
+        setError(getErrorMessage(err, 'Failed to update oscillation parameters'));
       }
     },
     150
@@ -91,7 +92,7 @@ export function useManualControl(ultra: Ultra | null): UseManualControlReturn {
 
       setIsRunning(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to upload funscript');
+      setError(getErrorMessage(err, 'Failed to upload funscript'));
       setIsRunning(false);
     } finally {
       isUploadingRef.current = false;
@@ -120,7 +121,7 @@ export function useManualControl(ultra: Ultra | null): UseManualControlReturn {
         await uploadAndStartFunscript();
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to start manual control');
+      setError(getErrorMessage(err, 'Failed to start manual control'));
     }
   }, [ultra, patternType, speed, minY, maxY, uploadAndStartFunscript]);
 
@@ -139,7 +140,7 @@ export function useManualControl(ultra: Ultra | null): UseManualControlReturn {
         await ultra.syncScriptStop();
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to stop manual control');
+      setError(getErrorMessage(err, 'Failed to stop manual control'));
     } finally {
       setIsRunning(false);
     }

--- a/src/hooks/useMigration.ts
+++ b/src/hooks/useMigration.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { db } from '@/lib/db';
 import { libraryApi } from '@/lib/apiClient';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 import type { CreateLibraryItemRequest } from '@/../server/types/shared';
 
 interface UseMigrationReturn {
@@ -65,7 +66,7 @@ export function useMigration(): UseMigrationReturn {
         setMigrating(false);
       } catch (err) {
         // Graceful error handling - backend may be unreachable
-        const errorMessage = err instanceof Error ? err.message : 'Migration failed';
+        const errorMessage = getErrorMessage(err, 'Migration failed');
         setError(errorMessage);
         setMigrating(false);
         console.warn('Migration failed, app will continue with IndexedDB fallback:', errorMessage);

--- a/src/hooks/usePatternEditor.ts
+++ b/src/hooks/usePatternEditor.ts
@@ -4,6 +4,7 @@ import type { FunscriptAction } from '@/types/funscript';
 import type { CustomPatternDefinition } from '@/types/patterns';
 import { scalePatternDuration, adjustIntensity, createLoopTransition } from '@/lib/patternTransform';
 import { customPatternApi } from '@/lib/apiClient';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 
 /**
  * Pattern editor hook managing full editing lifecycle
@@ -125,7 +126,7 @@ export function usePatternEditor() {
 
       setIsDemoPlaying(true);
     } catch (err) {
-      setDemoError(err instanceof Error ? err.message : 'Failed to start demo');
+      setDemoError(getErrorMessage(err, 'Failed to start demo'));
     }
   }, [editedPattern]);
 
@@ -138,7 +139,7 @@ export function usePatternEditor() {
       setIsDemoPlaying(false);
       setDemoError(null);
     } catch (err) {
-      setDemoError(err instanceof Error ? err.message : 'Failed to stop demo');
+      setDemoError(getErrorMessage(err, 'Failed to stop demo'));
     }
   }, []);
 
@@ -197,7 +198,7 @@ export function usePatternEditor() {
 
       setIsSaving(false);
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : 'Failed to save pattern');
+      setSaveError(getErrorMessage(err, 'Failed to save pattern'));
       setIsSaving(false);
     }
   }, [editedPattern]);

--- a/src/hooks/usePlaylistManager.ts
+++ b/src/hooks/usePlaylistManager.ts
@@ -5,6 +5,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { playlistApi, libraryApi } from '@/lib/apiClient';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 import type { Playlist, PlaylistItem, LibraryItem } from '../../server/types/shared';
 
 export interface UsePlaylistManagerReturn {
@@ -55,7 +56,7 @@ export function usePlaylistManager(): UsePlaylistManagerReturn {
       const results = await playlistApi.getAll();
       setPlaylists(results);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch playlists';
+      const errorMessage = getErrorMessage(err, 'Failed to fetch playlists');
       setError(errorMessage);
       setPlaylists([]);
     } finally {
@@ -75,7 +76,7 @@ export function usePlaylistManager(): UsePlaylistManagerReturn {
       await refresh();
       return created;
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to create playlist';
+      const errorMessage = getErrorMessage(err, 'Failed to create playlist');
       setError(errorMessage);
       throw err;
     }
@@ -94,7 +95,7 @@ export function usePlaylistManager(): UsePlaylistManagerReturn {
       }
       await refresh();
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to delete playlist';
+      const errorMessage = getErrorMessage(err, 'Failed to delete playlist');
       setError(errorMessage);
       throw err;
     }
@@ -111,7 +112,7 @@ export function usePlaylistManager(): UsePlaylistManagerReturn {
       setActivePlaylist(playlist);
       setActiveItems(items);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to load playlist';
+      const errorMessage = getErrorMessage(err, 'Failed to load playlist');
       setError(errorMessage);
       throw err;
     }
@@ -138,7 +139,7 @@ export function usePlaylistManager(): UsePlaylistManagerReturn {
       const items = await playlistApi.getItems(activePlaylist.id);
       setActiveItems(items);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to add item to playlist';
+      const errorMessage = getErrorMessage(err, 'Failed to add item to playlist');
       setError(errorMessage);
       throw err;
     }
@@ -157,7 +158,7 @@ export function usePlaylistManager(): UsePlaylistManagerReturn {
       const items = await playlistApi.getItems(activePlaylist.id);
       setActiveItems(items);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to remove item';
+      const errorMessage = getErrorMessage(err, 'Failed to remove item');
       setError(errorMessage);
       throw err;
     }
@@ -190,7 +191,7 @@ export function usePlaylistManager(): UsePlaylistManagerReturn {
     } catch (err) {
       // Revert on error
       setActiveItems(previousItems);
-      const errorMessage = err instanceof Error ? err.message : 'Failed to reorder items';
+      const errorMessage = getErrorMessage(err, 'Failed to reorder items');
       setError(errorMessage);
       throw err;
     }
@@ -208,7 +209,7 @@ export function usePlaylistManager(): UsePlaylistManagerReturn {
       const videoItems = items.filter((item) => item.videoName !== null);
       setLibraryItems(videoItems);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to load library items';
+      const errorMessage = getErrorMessage(err, 'Failed to load library items');
       setError(errorMessage);
       throw err;
     }

--- a/src/hooks/useSyncPlayback.ts
+++ b/src/hooks/useSyncPlayback.ts
@@ -3,6 +3,7 @@ import type { Ultra } from '@xsense/autoblow-sdk';
 import type { ZodFunscript } from '@/lib/schemas';
 import type { SyncStatus, UseSyncPlaybackReturn } from '@/types/sync';
 import { convertToSDKFunscript } from '@/lib/funscriptConverter';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 
 // Drift detection constants (per 05-RESEARCH.md Pattern 4)
 const DRIFT_CHECK_INTERVAL_MS = 2000; // Check every 2 seconds
@@ -143,7 +144,7 @@ export function useSyncPlayback(
       } catch (err) {
         console.error('Failed to upload funscript:', err);
         setSyncStatus('error');
-        setError(err instanceof Error ? err.message : 'Failed to upload funscript');
+        setError(getErrorMessage(err, 'Failed to upload funscript'));
         setScriptUploaded(false);
       }
     };
@@ -200,7 +201,7 @@ export function useSyncPlayback(
         if (generation !== generationRef.current) return;
         console.error('Failed to start sync:', err);
         setSyncStatus('error');
-        setError(err instanceof Error ? err.message : 'Failed to start sync');
+        setError(getErrorMessage(err, 'Failed to start sync'));
       }
     };
 
@@ -288,7 +289,7 @@ export function useSyncPlayback(
           if (generation !== generationRef.current) return;
           console.error('Failed to start embed sync:', err);
           setSyncStatus('error');
-          setError(err instanceof Error ? err.message : 'Failed to start sync');
+          setError(getErrorMessage(err, 'Failed to start sync'));
         }
       } else {
         // Stop sync

--- a/src/hooks/useWaypointBuilder.ts
+++ b/src/hooks/useWaypointBuilder.ts
@@ -5,6 +5,7 @@ import type { WaypointDefinition, CustomPatternDefinition } from '@/types/patter
 import { waypointsToActions } from '@/lib/waypointGenerator';
 import { createLoopTransition } from '@/lib/patternTransform';
 import { customPatternApi } from '@/lib/apiClient';
+import { getErrorMessage } from '@/lib/getErrorMessage';
 
 /**
  * Waypoint builder hook managing waypoint-based pattern creation lifecycle
@@ -186,7 +187,7 @@ export function useWaypointBuilder() {
 
       setIsDemoPlaying(true);
     } catch (err) {
-      setDemoError(err instanceof Error ? err.message : 'Failed to start demo');
+      setDemoError(getErrorMessage(err, 'Failed to start demo'));
     }
   }, [waypoints]);
 
@@ -199,7 +200,7 @@ export function useWaypointBuilder() {
       setIsDemoPlaying(false);
       setDemoError(null);
     } catch (err) {
-      setDemoError(err instanceof Error ? err.message : 'Failed to stop demo');
+      setDemoError(getErrorMessage(err, 'Failed to stop demo'));
     }
   }, []);
 
@@ -243,7 +244,7 @@ export function useWaypointBuilder() {
       setIsSaving(false);
       return savedItem;
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : 'Failed to save pattern');
+      setSaveError(getErrorMessage(err, 'Failed to save pattern'));
       setIsSaving(false);
       throw err;
     }

--- a/src/lib/getErrorMessage.ts
+++ b/src/lib/getErrorMessage.ts
@@ -1,0 +1,7 @@
+/**
+ * Extract a human-readable message from an unknown caught error.
+ * Returns the Error's message if available, otherwise the provided fallback.
+ */
+export function getErrorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}


### PR DESCRIPTION
## Summary
- Created `src/lib/getErrorMessage.ts` — a single utility function that replaces the repeated `err instanceof Error ? err.message : 'fallback'` pattern
- Replaced all 29 occurrences across 11 files:
  - `usePlaylistManager` (8), `useManualControl` (4), `useSyncPlayback` (3), `usePatternEditor` (3), `useWaypointBuilder` (3), `PatternDetailDialog` (2), `useLibrary` (2), `useEmbedPlayback` (1), `useFunscriptFile` (1), `useMigration` (1), `App.tsx` (1)
- Zero remaining `instanceof Error ? .message :` patterns in the codebase

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] All 35 existing tests pass (`npx vitest run`)
- [x] Grep confirms 0 remaining occurrences of the old pattern