### PR TITLE
refactor: extract DeviceProvider context and useUnifiedPlayback hook

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,13 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
-import type { ConnectionState, DeviceInfo } from '@/types/device';
+import { useDevice } from '@/contexts/DeviceContext';
 
 interface AppHeaderProps {
-  connectionState: ConnectionState;
-  deviceInfo: DeviceInfo | null;
-  error: string | null;
-  savedToken: string;
-  onConnect: (token: string) => void;
-  onDisconnect: () => void;
   onNewScript: () => void;
   isCreationMode: boolean;
 }
@@ -18,15 +12,10 @@ interface AppHeaderProps {
  * Shows connection status icon button in all states.
  */
 export function AppHeader({
-  connectionState,
-  deviceInfo,
-  error,
-  savedToken,
-  onConnect,
-  onDisconnect,
   onNewScript,
   isCreationMode,
 }: AppHeaderProps) {
+  const { connectionState, deviceInfo, deviceError: error, savedToken, connect, disconnect } = useDevice();
   const [tokenValue, setTokenValue] = useState(savedToken || '');
   const [showPopover, setShowPopover] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -54,7 +43,7 @@ export function AppHeader({
 
   const handleConnectClick = () => {
     if (tokenValue.trim()) {
-      onConnect(tokenValue.trim());
+      connect(tokenValue.trim());
     }
   };
 
@@ -67,13 +56,13 @@ export function AppHeader({
   };
 
   const handleDisconnect = () => {
-    onDisconnect();
+    disconnect();
     setShowPopover(false);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && tokenValue.trim()) {
-      onConnect(tokenValue.trim());
+      connect(tokenValue.trim());
     }
   };
 

--- a/src/components/pages/DeviceLogPage.tsx
+++ b/src/components/pages/DeviceLogPage.tsx
@@ -1,14 +1,11 @@
+import { useDevice } from '@/contexts/DeviceContext';
 import type { DeviceLogEntry } from '@/hooks/useDeviceLog';
-
-interface DeviceLogPageProps {
-  logs: DeviceLogEntry[];
-  onClearLogs: () => void;
-}
 
 /**
  * Device Log page - displays device communication log with timestamps
  */
-export function DeviceLogPage({ logs, onClearLogs }: DeviceLogPageProps) {
+export function DeviceLogPage() {
+  const { logs, clearLogs } = useDevice();
   const formatTimestamp = (date: Date): string => {
     const hours = date.getHours().toString().padStart(2, '0');
     const minutes = date.getMinutes().toString().padStart(2, '0');
@@ -60,7 +57,7 @@ export function DeviceLogPage({ logs, onClearLogs }: DeviceLogPageProps) {
             <h2 className="text-xl font-semibold">Device Communication Log</h2>
             {logs.length > 0 && (
               <button
-                onClick={onClearLogs}
+                onClick={clearLogs}
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
                 Clear

--- a/src/components/pages/ManualControlPage.tsx
+++ b/src/components/pages/ManualControlPage.tsx
@@ -1,5 +1,6 @@
 import { VideoLoader } from '@/components/file-loader/VideoLoader';
 import { ManualControls } from '@/components/device-control/ManualControls';
+import { useDevice } from '@/contexts/DeviceContext';
 import type { PatternType, ManualControlParams } from '@/types/device';
 
 interface ManualControlPageProps {
@@ -26,7 +27,6 @@ interface ManualControlPageProps {
   maxY: number;
   increment: number;
   variability: number;
-  isConnected: boolean;
   onStart: () => void;
   onStop: () => void;
   onParamChange: (params: Partial<ManualControlParams>) => void;
@@ -57,12 +57,12 @@ export function ManualControlPage({
   maxY,
   increment,
   variability,
-  isConnected,
   onStart,
   onStop,
   onParamChange,
   onPatternTypeChange,
 }: ManualControlPageProps) {
+  const { isDeviceConnected } = useDevice();
   return (
     <div role="tabpanel" id="panel-manual-control" aria-labelledby="tab-manual-control">
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-6">
@@ -95,7 +95,7 @@ export function ManualControlPage({
             maxY={maxY}
             increment={increment}
             variability={variability}
-            isConnected={isConnected}
+            isConnected={isDeviceConnected}
             onStart={onStart}
             onStop={onStop}
             onParamChange={onParamChange}

--- a/src/components/pages/PatternLibraryPage.tsx
+++ b/src/components/pages/PatternLibraryPage.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
-import type { Ultra } from '@xsense/autoblow-sdk';
 import type { PatternDefinition, CustomPatternDefinition, AnyPattern } from '@/types/patterns';
 import { PATTERN_DEFINITIONS } from '@/lib/patternDefinitions';
 import { usePatternFilters } from '@/hooks/usePatternFilters';
 import { usePatternEditor } from '@/hooks/usePatternEditor';
 import { useWaypointBuilder } from '@/hooks/useWaypointBuilder';
+import { useDevice } from '@/contexts/DeviceContext';
 import { PatternFilters } from '@/components/pattern-library/PatternFilters';
 import { PatternGrid } from '@/components/pattern-library/PatternGrid';
 import { PatternDetailDialog } from '@/components/pattern-library/PatternDetailDialog';
@@ -18,8 +18,6 @@ import type { LibraryItem } from '../../../server/types/shared';
 interface PatternLibraryPageProps {
   onInsert: (pattern: AnyPattern, position: 'cursor' | 'end') => void;
   isCreationMode?: boolean;
-  ultra: Ultra | null;
-  isDeviceConnected: boolean;
 }
 
 /**
@@ -51,9 +49,8 @@ function itemToCustomPattern(item: LibraryItem): CustomPatternDefinition {
 export function PatternLibraryPage({
   onInsert,
   isCreationMode = false,
-  ultra,
-  isDeviceConnected,
 }: PatternLibraryPageProps) {
+  const { ultra, isDeviceConnected } = useDevice();
   // Custom patterns state
   const [customPatterns, setCustomPatterns] = useState<CustomPatternDefinition[]>([]);
 

--- a/src/components/pages/VideoSyncPage.tsx
+++ b/src/components/pages/VideoSyncPage.tsx
@@ -2,6 +2,7 @@ import { VideoLoader } from '@/components/file-loader/VideoLoader';
 import { FunscriptLoader } from '@/components/file-loader/FunscriptLoader';
 import { SyncStatus } from '@/components/device-control/SyncStatus';
 import { ManualSyncControls } from '@/components/video-player/ManualSyncControls';
+import { useDevice } from '@/contexts/DeviceContext';
 import type { ZodFunscript } from '@/lib/schemas';
 import type { SyncStatus as SyncStatusType } from '@/types/sync';
 import type { PlatformConfig } from '@/types/video';
@@ -36,7 +37,6 @@ interface VideoSyncPageProps {
   scriptUploaded: boolean;
   driftMs: number;
   syncError: string | null;
-  isDeviceConnected: boolean;
   hasFunscript: boolean;
 
   // Timeline controls
@@ -99,7 +99,6 @@ export function VideoSyncPage({
   scriptUploaded,
   driftMs,
   syncError,
-  isDeviceConnected,
   hasFunscript,
   showTimeline,
   onToggleTimeline,
@@ -125,6 +124,8 @@ export function VideoSyncPage({
   isScriptPlaying,
   onToggleScript,
 }: VideoSyncPageProps) {
+  const { isDeviceConnected } = useDevice();
+
   return (
     <div role="tabpanel" id="panel-video-sync" aria-labelledby="tab-video-sync">
       <div className="max-w-4xl mx-auto space-y-6">

--- a/src/contexts/DeviceContext.tsx
+++ b/src/contexts/DeviceContext.tsx
@@ -1,0 +1,87 @@
+import { createContext, useContext, useEffect, useRef, type ReactNode } from 'react';
+import { useDeviceConnection } from '@/hooks/useDeviceConnection';
+import { useDeviceLog } from '@/hooks/useDeviceLog';
+import type { DeviceLogEntry } from '@/hooks/useDeviceLog';
+import type { ConnectionState, DeviceInfo } from '@/types/device';
+import type { Ultra } from '@xsense/autoblow-sdk';
+
+interface DeviceContextValue {
+  connectionState: ConnectionState;
+  deviceError: string | null;
+  deviceInfo: DeviceInfo | null;
+  connect: (token: string) => Promise<void>;
+  disconnect: () => void;
+  ultra: Ultra | null;
+  savedToken: string;
+  isDeviceConnected: boolean;
+  logs: DeviceLogEntry[];
+  addLog: (type: DeviceLogEntry['type'], message: string) => void;
+  clearLogs: () => void;
+}
+
+const DeviceContext = createContext<DeviceContextValue | null>(null);
+
+/**
+ * Provides device connection state, device logging, and connection-related
+ * log side-effects to the component tree. Consumers use useDevice() to access.
+ */
+export function DeviceProvider({ children }: { children: ReactNode }) {
+  const {
+    connectionState,
+    error: deviceError,
+    deviceInfo,
+    connect,
+    disconnect,
+    ultra,
+    savedToken,
+  } = useDeviceConnection();
+
+  const { logs, addLog, clearLogs } = useDeviceLog();
+  const isDeviceConnected = connectionState === 'connected';
+
+  // Track connection state changes in device log
+  const prevConnectionStateRef = useRef<ConnectionState>('disconnected');
+  useEffect(() => {
+    if (connectionState === 'connected' && prevConnectionStateRef.current !== 'connected') {
+      addLog('info', 'Device connected');
+    } else if (connectionState === 'disconnected' && prevConnectionStateRef.current === 'connected') {
+      addLog('info', 'Device disconnected');
+    }
+    prevConnectionStateRef.current = connectionState;
+  }, [connectionState, addLog]);
+
+  // Track device errors in device log
+  useEffect(() => {
+    if (deviceError) {
+      addLog('error', deviceError);
+    }
+  }, [deviceError, addLog]);
+
+  return (
+    <DeviceContext.Provider
+      value={{
+        connectionState,
+        deviceError,
+        deviceInfo,
+        connect,
+        disconnect,
+        ultra,
+        savedToken,
+        isDeviceConnected,
+        logs,
+        addLog,
+        clearLogs,
+      }}
+    >
+      {children}
+    </DeviceContext.Provider>
+  );
+}
+
+export function useDevice(): DeviceContextValue {
+  const context = useContext(DeviceContext);
+  if (!context) {
+    throw new Error('useDevice must be used within a DeviceProvider');
+  }
+  return context;
+}

--- a/src/hooks/useUnifiedPlayback.ts
+++ b/src/hooks/useUnifiedPlayback.ts
@@ -1,0 +1,55 @@
+import type { RefObject } from 'react';
+import { useVideoPlayback } from '@/hooks/useVideoPlayback';
+import { useEmbedPlayback } from '@/hooks/useEmbedPlayback';
+import { useManualSync } from '@/hooks/useManualSync';
+import { isEmbedUrl, detectPlatformConfig } from '@/lib/videoUtils';
+
+interface UseUnifiedPlaybackOptions {
+  videoRef: RefObject<HTMLVideoElement | null>;
+  videoUrl: string | null;
+  videoName: string | null;
+  embedPlayerRef: RefObject<HTMLVideoElement | null>;
+}
+
+/**
+ * Unifies local video playback and embed playback behind a single interface.
+ * Detects whether the loaded video is an embed URL and selects the appropriate
+ * playback system, exposing unified active* values for consumers.
+ */
+export function useUnifiedPlayback({
+  videoRef,
+  videoUrl,
+  videoName,
+  embedPlayerRef,
+}: UseUnifiedPlaybackOptions) {
+  const localPlayback = useVideoPlayback(videoRef, videoUrl);
+
+  const isEmbed = isEmbedUrl(videoName);
+  const platformConfig = detectPlatformConfig(isEmbed ? videoUrl : null);
+  const iframeEmbed = isEmbed && !platformConfig.canPlay;
+
+  const embedPlayback = useEmbedPlayback({
+    playerRef: embedPlayerRef,
+    embedUrl: isEmbed ? videoUrl : null,
+  });
+
+  const manualSync = useManualSync(platformConfig.requiresManualOffset && isEmbed);
+
+  return {
+    // Unified active values
+    activeIsPlaying: isEmbed ? embedPlayback.isPlaying : localPlayback.isPlaying,
+    activeCurrentTime: isEmbed ? embedPlayback.currentTime : localPlayback.currentTime,
+    activeDuration: isEmbed ? embedPlayback.duration : localPlayback.duration,
+    activeTogglePlayPause: isEmbed ? embedPlayback.togglePlayPause : localPlayback.togglePlayPause,
+    activeSeek: isEmbed ? embedPlayback.seek : localPlayback.seek,
+    activePlaybackError: isEmbed ? embedPlayback.error : localPlayback.error,
+    // Embed detection
+    isEmbed,
+    platformConfig,
+    iframeEmbed,
+    // Sub-hook returns for direct access
+    localPlayback,
+    embedPlayback,
+    manualSync,
+  };
+}


### PR DESCRIPTION
## Summary
- **DeviceProvider context** (`src/contexts/DeviceContext.tsx`) — co-locates device connection, device logging, and connection/error log side-effects. Exposes `useDevice()` hook for consumers.
- **useUnifiedPlayback hook** (`src/hooks/useUnifiedPlayback.ts`) — encapsulates embed/local playback detection and unification behind a single interface.
- **App.tsx split** into thin provider shell (`App`) + focused content (`AppContent`). Removed 6 unused imports, 2 device log effects, and all inline playback unification logic.
- **12 props eliminated** across 5 consumer components:
  - AppHeader: dropped 6 device props (connectionState, deviceInfo, error, savedToken, onConnect, onDisconnect)
  - ManualControlPage: dropped `isConnected`
  - PatternLibraryPage: dropped `ultra` + `isDeviceConnected`
  - VideoSyncPage: dropped `isDeviceConnected`
  - DeviceLogPage: dropped `logs` + `onClearLogs` (now prop-less)

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — all 35 tests pass
- [ ] Manual: verify device connection/disconnection still works
- [ ] Manual: verify device log page shows connection events
- [ ] Manual: verify pattern library demo playback with connected device
- [ ] Manual: verify video sync page shows correct sync status