### PR TITLE
refactor: split useTimelineEditor into 3 focused sub-hooks

### DIFF
--- a/src/hooks/useDrawMode.ts
+++ b/src/hooks/useDrawMode.ts
@@ -1,0 +1,98 @@
+import { useState, useCallback } from 'react';
+import type { FunscriptAction } from '@/types/funscript';
+import { xToTime, yToPos } from '@/lib/timelineHitDetection';
+
+const DRAW_SUBSAMPLE_MS = 50;
+
+interface UseDrawModeProps {
+  actions: FunscriptAction[];
+  setActions: (actions: FunscriptAction[]) => void;
+  viewStart: number;
+  viewEnd: number;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
+/**
+ * Manages free-draw point collection with subsampling and merge-on-release.
+ */
+export function useDrawMode({
+  actions,
+  setActions,
+  viewStart,
+  viewEnd,
+  canvasWidth,
+  canvasHeight,
+}: UseDrawModeProps) {
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [drawPoints, setDrawPoints] = useState<Array<{ timeMs: number; pos: number }>>([]);
+
+  const startDrawing = useCallback(
+    (mouseX: number, mouseY: number) => {
+      setIsDrawing(true);
+      const timeMs = xToTime(mouseX, viewStart, viewEnd, canvasWidth);
+      const pos = yToPos(mouseY, canvasHeight);
+      setDrawPoints([{ timeMs, pos }]);
+    },
+    [viewStart, viewEnd, canvasWidth, canvasHeight]
+  );
+
+  const continueDrawing = useCallback(
+    (mouseX: number, mouseY: number) => {
+      const timeMs = xToTime(mouseX, viewStart, viewEnd, canvasWidth);
+      const pos = yToPos(mouseY, canvasHeight);
+
+      setDrawPoints((prev) => {
+        if (prev.length > 0) {
+          const last = prev[prev.length - 1];
+          if (Math.abs(timeMs - last.timeMs) < DRAW_SUBSAMPLE_MS) {
+            return prev; // Too close — skip
+          }
+        }
+        return [...prev, { timeMs, pos }];
+      });
+    },
+    [viewStart, viewEnd, canvasWidth, canvasHeight]
+  );
+
+  const finalizeDrawing = useCallback(() => {
+    if (drawPoints.length === 0) {
+      setIsDrawing(false);
+      setDrawPoints([]);
+      return;
+    }
+
+    // Subsample to ensure minimum intervals
+    const subsampled: Array<{ timeMs: number; pos: number }> = [drawPoints[0]];
+    for (let i = 1; i < drawPoints.length - 1; i++) {
+      const last = subsampled[subsampled.length - 1];
+      if (drawPoints[i].timeMs - last.timeMs >= DRAW_SUBSAMPLE_MS) {
+        subsampled.push(drawPoints[i]);
+      }
+    }
+    if (drawPoints.length > 1) {
+      subsampled.push(drawPoints[drawPoints.length - 1]);
+    }
+
+    // Convert to clamped FunscriptActions
+    const newActions: FunscriptAction[] = subsampled.map((pt) => ({
+      at: Math.round(pt.timeMs),
+      pos: Math.round(Math.max(0, Math.min(100, pt.pos))),
+    }));
+
+    // Merge with existing actions and sort
+    const merged = [...actions, ...newActions].sort((a, b) => a.at - b.at);
+    setActions(merged);
+
+    setIsDrawing(false);
+    setDrawPoints([]);
+  }, [actions, setActions, drawPoints]);
+
+  return {
+    isDrawing,
+    drawPoints,
+    startDrawing,
+    continueDrawing,
+    finalizeDrawing,
+  };
+}

--- a/src/hooks/usePointDrag.ts
+++ b/src/hooks/usePointDrag.ts
@@ -1,0 +1,120 @@
+import { useState, useRef, useCallback } from 'react';
+import type { FunscriptAction } from '@/types/funscript';
+import { xToTime, yToPos } from '@/lib/timelineHitDetection';
+
+const DRAG_THRESHOLD_PX = 5;
+
+interface DragPreview {
+  index: number;
+  timeMs: number;
+  pos: number;
+}
+
+interface UsePointDragProps {
+  actions: FunscriptAction[];
+  setActions: (actions: FunscriptAction[]) => void;
+  viewStart: number;
+  viewEnd: number;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
+/**
+ * Manages threshold-based point dragging with live preview and commit-on-release.
+ */
+export function usePointDrag({
+  actions,
+  setActions,
+  viewStart,
+  viewEnd,
+  canvasWidth,
+  canvasHeight,
+}: UsePointDragProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragPreview, setDragPreview] = useState<DragPreview | null>(null);
+
+  const dragPointIndexRef = useRef<number | null>(null);
+  const dragStartPosRef = useRef<{ x: number; y: number; timeMs: number; pos: number } | null>(null);
+  const dragThresholdMetRef = useRef(false);
+
+  const startTracking = useCallback(
+    (index: number, action: FunscriptAction, mouseX: number, mouseY: number) => {
+      dragPointIndexRef.current = index;
+      dragStartPosRef.current = { x: mouseX, y: mouseY, timeMs: action.at, pos: action.pos };
+      dragThresholdMetRef.current = false;
+      setIsDragging(false);
+    },
+    []
+  );
+
+  const updateTracking = useCallback(
+    (mouseX: number, mouseY: number) => {
+      if (dragPointIndexRef.current === null || !dragStartPosRef.current) return;
+
+      const dx = mouseX - dragStartPosRef.current.x;
+      const dy = mouseY - dragStartPosRef.current.y;
+
+      if (!dragThresholdMetRef.current && Math.sqrt(dx * dx + dy * dy) > DRAG_THRESHOLD_PX) {
+        dragThresholdMetRef.current = true;
+        setIsDragging(true);
+      }
+
+      if (dragThresholdMetRef.current) {
+        setDragPreview({
+          index: dragPointIndexRef.current,
+          timeMs: xToTime(mouseX, viewStart, viewEnd, canvasWidth),
+          pos: yToPos(mouseY, canvasHeight),
+        });
+      }
+    },
+    [viewStart, viewEnd, canvasWidth, canvasHeight]
+  );
+
+  /**
+   * Finalize drag tracking. Returns the tracked point index and whether
+   * a real drag occurred (true) or it was just a click (false).
+   */
+  const finalizeTracking = useCallback(
+    (mouseX: number, mouseY: number): { wasDrag: boolean; index: number } | null => {
+      if (dragPointIndexRef.current === null || !dragStartPosRef.current) return null;
+
+      const index = dragPointIndexRef.current;
+      let wasDrag = false;
+
+      if (dragThresholdMetRef.current) {
+        // Commit the move
+        const newTimeMs = xToTime(mouseX, viewStart, viewEnd, canvasWidth);
+        const newPos = yToPos(mouseY, canvasHeight);
+
+        const newActions = actions.map((action, i) =>
+          i === index
+            ? { at: Math.round(newTimeMs), pos: Math.round(Math.max(0, Math.min(100, newPos))) }
+            : action
+        );
+        newActions.sort((a, b) => a.at - b.at);
+        setActions(newActions);
+
+        setIsDragging(false);
+        setDragPreview(null);
+        wasDrag = true;
+      }
+
+      // Clear tracking state
+      dragPointIndexRef.current = null;
+      dragStartPosRef.current = null;
+      dragThresholdMetRef.current = false;
+
+      return { wasDrag, index };
+    },
+    [actions, setActions, viewStart, viewEnd, canvasWidth, canvasHeight]
+  );
+
+  return {
+    isDragging,
+    dragPreview,
+    startTracking,
+    updateTracking,
+    finalizeTracking,
+    get isTracking() { return dragPointIndexRef.current !== null; },
+  };
+}

--- a/src/hooks/usePointSelection.ts
+++ b/src/hooks/usePointSelection.ts
@@ -1,0 +1,143 @@
+import { useState, useRef, useCallback } from 'react';
+import type { FunscriptAction } from '@/types/funscript';
+import type { SelectionRect, HitTestResult } from '@/types/timeline';
+import {
+  hitTestActionPoint,
+  getPointsInRect,
+} from '@/lib/timelineHitDetection';
+
+const SELECTION_THRESHOLD_PX = 5;
+
+interface UsePointSelectionProps {
+  actions: FunscriptAction[];
+  viewStart: number;
+  viewEnd: number;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
+/**
+ * Manages point selection state: click-to-select, rectangle selection, and hover tracking.
+ */
+export function usePointSelection({
+  actions,
+  viewStart,
+  viewEnd,
+  canvasWidth,
+  canvasHeight,
+}: UsePointSelectionProps) {
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [selectionRect, setSelectionRect] = useState<SelectionRect | null>(null);
+
+  const rectStartRef = useRef<{ x: number; y: number } | null>(null);
+  const isSelectingRef = useRef(false);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIndices(new Set());
+  }, []);
+
+  const hitTest = useCallback(
+    (mouseX: number, mouseY: number): HitTestResult | null =>
+      hitTestActionPoint(mouseX, mouseY, actions, viewStart, viewEnd, canvasWidth, canvasHeight),
+    [actions, viewStart, viewEnd, canvasWidth, canvasHeight]
+  );
+
+  const updateHover = useCallback(
+    (mouseX: number, mouseY: number) => {
+      const result = hitTest(mouseX, mouseY);
+      setHoveredIndex(result ? result.index : null);
+    },
+    [hitTest]
+  );
+
+  const togglePoint = useCallback(
+    (index: number) => {
+      if (selectedIndices.has(index)) {
+        const next = new Set(selectedIndices);
+        next.delete(index);
+        setSelectedIndices(next);
+      } else {
+        setSelectedIndices(new Set([index]));
+      }
+    },
+    [selectedIndices]
+  );
+
+  const startRectSelection = useCallback((mouseX: number, mouseY: number) => {
+    rectStartRef.current = { x: mouseX, y: mouseY };
+    isSelectingRef.current = false;
+  }, []);
+
+  /** Update the selection rectangle. Returns true when actively selecting (threshold met). */
+  const updateRectSelection = useCallback(
+    (mouseX: number, mouseY: number): boolean => {
+      if (!rectStartRef.current) return false;
+
+      const dx = mouseX - rectStartRef.current.x;
+      const dy = mouseY - rectStartRef.current.y;
+
+      if (!isSelectingRef.current && Math.sqrt(dx * dx + dy * dy) > SELECTION_THRESHOLD_PX) {
+        isSelectingRef.current = true;
+      }
+
+      if (isSelectingRef.current) {
+        setSelectionRect({
+          startX: rectStartRef.current.x,
+          startY: rectStartRef.current.y,
+          endX: mouseX,
+          endY: mouseY,
+        });
+        return true;
+      }
+
+      return false;
+    },
+    []
+  );
+
+  const finalizeRectSelection = useCallback(
+    (shiftHeld: boolean) => {
+      if (!isSelectingRef.current || !selectionRect) return;
+
+      const indicesInRect = getPointsInRect(
+        selectionRect, actions, viewStart, viewEnd, canvasWidth, canvasHeight
+      );
+
+      if (shiftHeld) {
+        const next = new Set(selectedIndices);
+        indicesInRect.forEach((idx) => next.add(idx));
+        setSelectedIndices(next);
+      } else {
+        setSelectedIndices(new Set(indicesInRect));
+      }
+
+      setSelectionRect(null);
+      rectStartRef.current = null;
+      isSelectingRef.current = false;
+    },
+    [actions, viewStart, viewEnd, canvasWidth, canvasHeight, selectionRect, selectedIndices]
+  );
+
+  /** Clean up rect selection state if the click didn't exceed the threshold. */
+  const cancelRectSelection = useCallback(() => {
+    if (rectStartRef.current && !isSelectingRef.current) {
+      rectStartRef.current = null;
+    }
+  }, []);
+
+  return {
+    selectedIndices,
+    hoveredIndex,
+    selectionRect,
+    clearSelection,
+    hitTest,
+    updateHover,
+    togglePoint,
+    startRectSelection,
+    updateRectSelection,
+    finalizeRectSelection,
+    cancelRectSelection,
+    get isSelecting() { return isSelectingRef.current; },
+  };
+}

--- a/src/hooks/useTimelineEditor.ts
+++ b/src/hooks/useTimelineEditor.ts
@@ -1,12 +1,10 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import type { FunscriptAction } from '@/types/funscript';
 import type { EditMode, SelectionRect } from '@/types/timeline';
-import {
-  hitTestActionPoint,
-  xToTime,
-  yToPos,
-  getPointsInRect,
-} from '@/lib/timelineHitDetection';
+import { xToTime, yToPos } from '@/lib/timelineHitDetection';
+import { usePointSelection } from '@/hooks/usePointSelection';
+import { usePointDrag } from '@/hooks/usePointDrag';
+import { useDrawMode } from '@/hooks/useDrawMode';
 
 interface UseTimelineEditorProps {
   actions: FunscriptAction[];
@@ -22,9 +20,6 @@ interface DragPreview {
   timeMs: number;
   pos: number;
 }
-
-const DRAG_THRESHOLD_PX = 5;
-const DRAW_SUBSAMPLE_MS = 50; // Minimum time gap between drawn points
 
 export interface UseTimelineEditorReturn {
   mode: EditMode;
@@ -45,6 +40,10 @@ export interface UseTimelineEditorReturn {
   addPoint: (timeMs: number, pos: number) => void;
 }
 
+/**
+ * Thin orchestrator that coordinates selection, drag, and draw sub-hooks
+ * and routes mouse events to the appropriate subsystem.
+ */
 export function useTimelineEditor({
   actions,
   setActions,
@@ -54,22 +53,12 @@ export function useTimelineEditor({
   canvasHeight,
 }: UseTimelineEditorProps): UseTimelineEditorReturn {
   const [mode, setMode] = useState<EditMode>('select');
-  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragPreview, setDragPreview] = useState<DragPreview | null>(null);
-  const [isDrawing, setIsDrawing] = useState(false);
-  const [drawPoints, setDrawPoints] = useState<Array<{ timeMs: number; pos: number }>>([]);
-  const [selectionRect, setSelectionRect] = useState<SelectionRect | null>(null);
 
-  // Drag state refs (avoid re-renders during drag)
-  const dragPointIndexRef = useRef<number | null>(null);
-  const dragStartPosRef = useRef<{ x: number; y: number; timeMs: number; pos: number } | null>(null);
-  const dragThresholdMetRef = useRef(false);
+  const coordParams = { viewStart, viewEnd, canvasWidth, canvasHeight };
 
-  // Rectangle selection refs
-  const rectStartRef = useRef<{ x: number; y: number } | null>(null);
-  const isSelectingRef = useRef(false);
+  const selection = usePointSelection({ actions, ...coordParams });
+  const drag = usePointDrag({ actions, setActions, ...coordParams });
+  const draw = useDrawMode({ actions, setActions, ...coordParams });
 
   const addPoint = useCallback(
     (timeMs: number, pos: number) => {
@@ -77,7 +66,6 @@ export function useTimelineEditor({
         at: Math.round(timeMs),
         pos: Math.round(Math.max(0, Math.min(100, pos))),
       };
-
       const newActions = [...actions, newAction].sort((a, b) => a.at - b.at);
       setActions(newActions);
     },
@@ -85,305 +73,102 @@ export function useTimelineEditor({
   );
 
   const deleteSelected = useCallback(() => {
-    if (selectedIndices.size === 0) return;
-
-    const indicesToDelete = new Set(selectedIndices);
-    const newActions = actions.filter((_, index) => !indicesToDelete.has(index));
-    setActions(newActions);
-    setSelectedIndices(new Set());
-  }, [actions, selectedIndices, setActions]);
-
-
-  const movePoint = useCallback(
-    (index: number, newTimeMs: number, newPos: number) => {
-      const newActions = actions.map((action, i) => {
-        if (i === index) {
-          return {
-            at: Math.round(newTimeMs),
-            pos: Math.round(Math.max(0, Math.min(100, newPos))),
-          };
-        }
-        return action;
-      });
-
-      // Sort by time after modification
-      newActions.sort((a, b) => a.at - b.at);
-      setActions(newActions);
-    },
-    [actions, setActions]
-  );
-
-  const clearSelection = useCallback(() => {
-    setSelectedIndices(new Set());
-  }, []);
+    if (selection.selectedIndices.size === 0) return;
+    const toDelete = new Set(selection.selectedIndices);
+    setActions(actions.filter((_, i) => !toDelete.has(i)));
+    selection.clearSelection();
+  }, [actions, selection.selectedIndices, selection.clearSelection, setActions]);
 
   const handleMouseDown = useCallback(
     (mouseX: number, mouseY: number, e: React.MouseEvent) => {
       if (mode === 'draw') {
-        // Start drawing
-        setIsDrawing(true);
-        const timeMs = xToTime(mouseX, viewStart, viewEnd, canvasWidth);
-        const pos = yToPos(mouseY, canvasHeight);
-        setDrawPoints([{ timeMs, pos }]);
+        draw.startDrawing(mouseX, mouseY);
         return;
       }
 
-      const hitResult = hitTestActionPoint(
-        mouseX,
-        mouseY,
-        actions,
-        viewStart,
-        viewEnd,
-        canvasWidth,
-        canvasHeight
-      );
-
-      if (hitResult) {
-        // Hit a point - start drag tracking
-        dragPointIndexRef.current = hitResult.index;
-        dragStartPosRef.current = {
-          x: mouseX,
-          y: mouseY,
-          timeMs: hitResult.action.at,
-          pos: hitResult.action.pos,
-        };
-        dragThresholdMetRef.current = false;
-        setIsDragging(false); // Not yet dragging (waiting for threshold)
-      } else {
-        // No hit - potential rectangle selection in select mode
-        if (mode === 'select') {
-          // Store start position for potential rectangle selection
-          rectStartRef.current = { x: mouseX, y: mouseY };
-          isSelectingRef.current = false; // Not yet selecting (waiting for drag threshold)
-        }
+      const hit = selection.hitTest(mouseX, mouseY);
+      if (hit) {
+        drag.startTracking(hit.index, hit.action as FunscriptAction, mouseX, mouseY);
+      } else if (mode === 'select') {
+        selection.startRectSelection(mouseX, mouseY);
       }
     },
-    [actions, viewStart, viewEnd, canvasWidth, canvasHeight, mode]
+    [mode, selection, drag, draw]
   );
 
   const handleMouseMove = useCallback(
     (mouseX: number, mouseY: number) => {
-      // Handle draw mode
-      if (isDrawing && mode === 'draw') {
-        const timeMs = xToTime(mouseX, viewStart, viewEnd, canvasWidth);
-        const pos = yToPos(mouseY, canvasHeight);
-
-        // Subsample: only add if time diff from last point >= 50ms
-        if (drawPoints.length > 0) {
-          const lastPoint = drawPoints[drawPoints.length - 1];
-          if (Math.abs(timeMs - lastPoint.timeMs) < DRAW_SUBSAMPLE_MS) {
-            return; // Skip this point - too close to last one
-          }
-        }
-
-        setDrawPoints([...drawPoints, { timeMs, pos }]);
+      // Draw mode
+      if (draw.isDrawing && mode === 'draw') {
+        draw.continueDrawing(mouseX, mouseY);
         return;
       }
 
-      // Handle rectangle selection
-      if (rectStartRef.current && mode === 'select' && !dragPointIndexRef.current) {
-        const dx = mouseX - rectStartRef.current.x;
-        const dy = mouseY - rectStartRef.current.y;
-        const distance = Math.sqrt(dx * dx + dy * dy);
-
-        if (!isSelectingRef.current && distance > DRAG_THRESHOLD_PX) {
-          // Threshold met - start rectangle selection
-          isSelectingRef.current = true;
-        }
-
-        if (isSelectingRef.current) {
-          // Update selection rectangle
-          setSelectionRect({
-            startX: rectStartRef.current.x,
-            startY: rectStartRef.current.y,
-            endX: mouseX,
-            endY: mouseY,
-          });
-          return; // Don't update hover during rectangle selection
+      // Rectangle selection (only when not tracking a drag)
+      if (mode === 'select' && !drag.isTracking) {
+        if (selection.updateRectSelection(mouseX, mouseY)) {
+          return; // Actively selecting — skip hover
         }
       }
 
-      // Update hover state
-      const hitResult = hitTestActionPoint(
-        mouseX,
-        mouseY,
-        actions,
-        viewStart,
-        viewEnd,
-        canvasWidth,
-        canvasHeight
-      );
-      setHoveredIndex(hitResult ? hitResult.index : null);
+      // Hover
+      selection.updateHover(mouseX, mouseY);
 
-      // Handle dragging
-      if (dragPointIndexRef.current !== null && dragStartPosRef.current) {
-        const dx = mouseX - dragStartPosRef.current.x;
-        const dy = mouseY - dragStartPosRef.current.y;
-        const distance = Math.sqrt(dx * dx + dy * dy);
-
-        if (!dragThresholdMetRef.current && distance > DRAG_THRESHOLD_PX) {
-          // Threshold met - start actual drag
-          dragThresholdMetRef.current = true;
-          setIsDragging(true);
-        }
-
-        if (dragThresholdMetRef.current) {
-          // Calculate new position from mouse
-          const newTimeMs = xToTime(mouseX, viewStart, viewEnd, canvasWidth);
-          const newPos = yToPos(mouseY, canvasHeight);
-
-          setDragPreview({
-            index: dragPointIndexRef.current,
-            timeMs: newTimeMs,
-            pos: newPos,
-          });
-        }
-      }
+      // Drag tracking
+      drag.updateTracking(mouseX, mouseY);
     },
-    [actions, viewStart, viewEnd, canvasWidth, canvasHeight, isDrawing, mode, drawPoints]
+    [mode, draw, drag, selection]
   );
 
   const handleMouseUp = useCallback(
     (_mouseX: number, _mouseY: number, e?: React.MouseEvent) => {
-      // Handle draw mode
-      if (isDrawing && mode === 'draw') {
-        // Finalize the drawn curve
-        if (drawPoints.length > 0) {
-          // Subsample to ensure minimum 50ms intervals
-          const subsampledPoints: Array<{ timeMs: number; pos: number }> = [];
-          subsampledPoints.push(drawPoints[0]); // Always keep first point
-
-          for (let i = 1; i < drawPoints.length - 1; i++) {
-            const lastKept = subsampledPoints[subsampledPoints.length - 1];
-            if (drawPoints[i].timeMs - lastKept.timeMs >= DRAW_SUBSAMPLE_MS) {
-              subsampledPoints.push(drawPoints[i]);
-            }
-          }
-
-          // Always keep last point
-          if (drawPoints.length > 1) {
-            subsampledPoints.push(drawPoints[drawPoints.length - 1]);
-          }
-
-          // Convert to FunscriptActions (clamp and round)
-          const newActions: FunscriptAction[] = subsampledPoints.map((point) => ({
-            at: Math.round(point.timeMs),
-            pos: Math.round(Math.max(0, Math.min(100, point.pos))),
-          }));
-
-          // Merge with existing actions and sort
-          const mergedActions = [...actions, ...newActions].sort((a, b) => a.at - b.at);
-          setActions(mergedActions);
-        }
-
-        // Clear drawing state
-        setIsDrawing(false);
-        setDrawPoints([]);
+      // Finalize draw
+      if (draw.isDrawing && mode === 'draw') {
+        draw.finalizeDrawing();
         return;
       }
 
-      // Handle rectangle selection
-      if (isSelectingRef.current && selectionRect && mode === 'select') {
-        // Find all points within rectangle
-        const indicesInRect = getPointsInRect(
-          selectionRect,
-          actions,
-          viewStart,
-          viewEnd,
-          canvasWidth,
-          canvasHeight
-        );
-
-        // Check if Shift is held
-        const shiftHeld = e?.shiftKey ?? false;
-
-        if (shiftHeld) {
-          // Add to existing selection
-          const newSelection = new Set(selectedIndices);
-          indicesInRect.forEach((idx) => newSelection.add(idx));
-          setSelectedIndices(newSelection);
-        } else {
-          // Replace selection
-          setSelectedIndices(new Set(indicesInRect));
-        }
-
-        // Clear rectangle selection state
-        setSelectionRect(null);
-        rectStartRef.current = null;
-        isSelectingRef.current = false;
+      // Finalize rectangle selection
+      if (selection.isSelecting && selection.selectionRect) {
+        selection.finalizeRectSelection(e?.shiftKey ?? false);
         return;
       }
 
-      if (dragPointIndexRef.current !== null && dragStartPosRef.current) {
-        if (dragThresholdMetRef.current) {
-          // Was dragging - commit the move
-          const newTimeMs = xToTime(_mouseX, viewStart, viewEnd, canvasWidth);
-          const newPos = yToPos(_mouseY, canvasHeight);
-          movePoint(dragPointIndexRef.current, newTimeMs, newPos);
-          setIsDragging(false);
-          setDragPreview(null);
-        } else {
-          // Was a click (not a drag) - select the point
-          const index = dragPointIndexRef.current;
-          if (selectedIndices.has(index)) {
-            // Deselect
-            const newSelection = new Set(selectedIndices);
-            newSelection.delete(index);
-            setSelectedIndices(newSelection);
-          } else {
-            // Select (replace current selection)
-            setSelectedIndices(new Set([index]));
-          }
-        }
-
-        // Clear drag state
-        dragPointIndexRef.current = null;
-        dragStartPosRef.current = null;
-        dragThresholdMetRef.current = false;
+      // Finalize drag (or handle click-to-select)
+      const result = drag.finalizeTracking(_mouseX, _mouseY);
+      if (result && !result.wasDrag) {
+        selection.togglePoint(result.index);
       }
 
-      // Clear rectangle selection if it was just a click (didn't exceed threshold)
-      if (rectStartRef.current && !isSelectingRef.current) {
-        rectStartRef.current = null;
-      }
+      // Clean up rect start if it was just a click
+      selection.cancelRectSelection();
     },
-    [viewStart, viewEnd, canvasWidth, canvasHeight, movePoint, selectedIndices, isDrawing, mode, drawPoints, actions, setActions, selectionRect]
+    [mode, draw, drag, selection]
   );
 
   const handleDoubleClick = useCallback(
     (mouseX: number, mouseY: number) => {
-      // Check if double-click hit an existing point
-      const hitResult = hitTestActionPoint(
-        mouseX,
-        mouseY,
-        actions,
-        viewStart,
-        viewEnd,
-        canvasWidth,
-        canvasHeight
-      );
-
-      if (!hitResult) {
-        // No existing point - add a new one
+      const hit = selection.hitTest(mouseX, mouseY);
+      if (!hit) {
         const timeMs = xToTime(mouseX, viewStart, viewEnd, canvasWidth);
         const pos = yToPos(mouseY, canvasHeight);
         addPoint(timeMs, pos);
       }
     },
-    [actions, viewStart, viewEnd, canvasWidth, canvasHeight, addPoint]
+    [selection, viewStart, viewEnd, canvasWidth, canvasHeight, addPoint]
   );
 
   return {
     mode,
     setMode,
-    selectedIndices,
-    clearSelection,
-    hoveredIndex,
-    isDragging,
-    dragPreview,
-    isDrawing,
-    drawPoints,
-    selectionRect,
+    selectedIndices: selection.selectedIndices,
+    clearSelection: selection.clearSelection,
+    hoveredIndex: selection.hoveredIndex,
+    isDragging: drag.isDragging,
+    dragPreview: drag.dragPreview,
+    isDrawing: draw.isDrawing,
+    drawPoints: draw.drawPoints,
+    selectionRect: selection.selectionRect,
     handleMouseDown,
     handleMouseMove,
     handleMouseUp,


### PR DESCRIPTION
## Summary
- Decomposed the 395-line `useTimelineEditor` monolith into 3 single-responsibility sub-hooks:
  - **`usePointSelection`** (143 lines) — click-to-select, rectangle selection, hover tracking
  - **`usePointDrag`** (120 lines) — threshold-based drag with live preview and commit-on-release
  - **`useDrawMode`** (98 lines) — freehand draw with time-based subsampling and merge-on-release
- `useTimelineEditor` is now a thin 179-line orchestrator that routes mouse events to the appropriate sub-hook
- Return interface unchanged — **zero consumer changes** (Timeline.tsx untouched)

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 35 existing tests pass (`npx vitest run`)
- [ ] Manual: select mode — click to select/deselect points, rectangle drag selection, shift+rect to add
- [ ] Manual: drag mode — click+drag a point past threshold, preview renders, release commits move
- [ ] Manual: draw mode — freehand draw creates subsampled points, merged on release
- [ ] Manual: double-click empty space adds a point
- [ ] Manual: delete selected points with keyboard shortcut