### PR TITLE
refactor: import shared timeline constants from timelineHitDetection

### DIFF
--- a/src/components/timeline/PlayheadOverlay.tsx
+++ b/src/components/timeline/PlayheadOverlay.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import type { FunscriptAction } from '@/types/funscript';
+import { timeToX, posToY } from '@/lib/timelineHitDetection';
 
 interface PlayheadOverlayProps {
   currentTimeMs: number;
@@ -9,9 +9,6 @@ interface PlayheadOverlayProps {
   height: number;
   actions: Array<{ pos: number; at: number }>;
 }
-
-const TOP_PADDING = 20;
-const BOTTOM_PADDING = 30;
 
 /**
  * Binary search to find the action closest to the given time
@@ -64,18 +61,6 @@ export const PlayheadOverlay = React.memo<PlayheadOverlayProps>(
       return findClosestAction(actions, currentTimeMs);
     }, [actions, currentTimeMs]);
 
-    // Helper: map position to y coordinate (100 = top, 0 = bottom)
-    const posToY = (pos: number): number => {
-      const chartHeight = height - TOP_PADDING - BOTTOM_PADDING;
-      return TOP_PADDING + chartHeight * (1 - pos / 100);
-    };
-
-    // Helper: map time to x coordinate
-    const timeToX = (timeMs: number): number => {
-      const ratio = (timeMs - viewStart) / (viewEnd - viewStart);
-      return ratio * width;
-    };
-
     // Calculate current action position if visible
     const currentActionPos = useMemo(() => {
       if (!currentAction) return null;
@@ -83,8 +68,8 @@ export const PlayheadOverlay = React.memo<PlayheadOverlayProps>(
         return null; // Action not in viewport
       }
       return {
-        x: timeToX(currentAction.at),
-        y: posToY(currentAction.pos),
+        x: timeToX(currentAction.at, viewStart, viewEnd, width),
+        y: posToY(currentAction.pos, height),
       };
     }, [currentAction, viewStart, viewEnd, width, height]);
 

--- a/src/lib/timelineHitDetection.ts
+++ b/src/lib/timelineHitDetection.ts
@@ -1,7 +1,6 @@
 import type { FunscriptAction } from '@/types/funscript';
 import type { HitTestResult, SelectionRect } from '@/types/timeline';
 
-// Constants matching TimelineCanvas.tsx
 export const HIT_RADIUS_PX = 8;
 export const TOP_PADDING = 20;
 export const BOTTOM_PADDING = 30;


### PR DESCRIPTION
## Summary
- Eliminated duplicate `TOP_PADDING`, `BOTTOM_PADDING`, `posToY`, and `timeToX` from **TimelineCanvas.tsx** and **PlayheadOverlay.tsx**
- Both now import from `timelineHitDetection.ts` — the single source of truth
- Removed stale "matching TimelineCanvas" comment from the canonical module
- Removed unused `FunscriptAction` type import from TimelineCanvas
- Net: -31 lines (47 removed, 16 added)

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 35 existing tests pass (`npx vitest run`)
- [ ] Manual: timeline canvas renders action points, gradient fill, grid lines correctly
- [ ] Manual: playhead overlay tracks current position with amber line and action highlight
- [ ] Manual: zooming/panning maintains correct coordinate mapping