### PR TITLE
refactor: create useAsyncOperation hook to DRY up async state management

### DIFF
--- a/src/hooks/useAsyncOperation.ts
+++ b/src/hooks/useAsyncOperation.ts
@@ -1,0 +1,57 @@
+import { useState, useCallback } from 'react';
+import { getErrorMessage } from '@/lib/getErrorMessage';
+
+interface UseAsyncOperationReturn {
+  loading: boolean;
+  error: string | null;
+  /** Run an async operation with loading state tracking (for primary data fetches). */
+  run: <T>(operation: () => Promise<T>, errorContext: string) => Promise<T>;
+  /** Execute an async operation without loading tracking (for mutations/actions). */
+  execute: <T>(operation: () => Promise<T>, errorContext: string) => Promise<T>;
+  clearError: () => void;
+}
+
+/**
+ * Manages loading/error state for async operations.
+ *
+ * - `run` sets loading=true while the operation is in-flight (use for data fetches).
+ * - `execute` only manages the error state (use for one-shot mutations).
+ * - Both clear the previous error before starting and re-throw on failure.
+ */
+export function useAsyncOperation(initialLoading = false): UseAsyncOperationReturn {
+  const [loading, setLoading] = useState(initialLoading);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(async <T>(
+    operation: () => Promise<T>,
+    errorContext: string,
+  ): Promise<T> => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await operation();
+    } catch (err) {
+      setError(getErrorMessage(err, errorContext));
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const execute = useCallback(async <T>(
+    operation: () => Promise<T>,
+    errorContext: string,
+  ): Promise<T> => {
+    setError(null);
+    try {
+      return await operation();
+    } catch (err) {
+      setError(getErrorMessage(err, errorContext));
+      throw err;
+    }
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return { loading, error, run, execute, clearError };
+}


### PR DESCRIPTION
## Summary
- New **`useAsyncOperation`** hook (57 lines) provides two wrappers:
  - `run()` — tracks loading + error state (for primary data fetches)
  - `execute()` — tracks error state only (for mutations/actions)
- Refactored **useLibrary**: eliminated manual `setLoading`/`setError`/`getErrorMessage` boilerplate from `fetchItems` and `deleteItem`
- Refactored **usePlaylistManager**: eliminated try/catch/setError/throw boilerplate from 8 operations
- Return interfaces unchanged — **zero consumer changes**
- Net: +17 lines (130 added, 113 removed) — new reusable hook offsets removed boilerplate

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 35 existing tests pass (`npx vitest run`)
- [ ] Manual: library page loads items, search works, delete works, error states display
- [ ] Manual: playlist page loads playlists, CRUD operations work, optimistic reorder reverts on failure