### PR TITLE
refactor: parameterize pattern definitions with helpers

### DIFF
--- a/src/lib/patternDefinitions.ts
+++ b/src/lib/patternDefinitions.ts
@@ -46,19 +46,56 @@ export function getPatternDirection(
   return 'neutral';
 }
 
+// ---------------------------------------------------------------------------
+// Pattern helpers
+// ---------------------------------------------------------------------------
+
+interface PatternMetadata {
+  id: string;
+  name: string;
+  intensity: Intensity;
+  tags: StyleTag[];
+  durationMs: number;
+}
+
+/** Flip every pos value (100 − pos) to create the directional mirror. */
+function mirrorActions(actions: FunscriptAction[]): FunscriptAction[] {
+  return actions.map(({ at, pos }) => ({ at, pos: 100 - pos }));
+}
+
+/** Generate N+1 evenly-spaced points ramping from 0 → 100. */
+function linearRamp(steps: number, durationMs: number): FunscriptAction[] {
+  return Array.from({ length: steps + 1 }, (_, i) => ({
+    pos: Math.round((i / steps) * 100),
+    at: Math.round((i / steps) * durationMs),
+  }));
+}
+
 /**
- * Complete pattern library with 36+ motion patterns
- * Sorted by intensity, then name
+ * Define a base pattern and its directional mirror in one call.
+ * Returns [base, mirror] where the mirror has 100 − pos for every point.
  */
+function patternPair(
+  baseMeta: PatternMetadata,
+  baseActions: FunscriptAction[],
+  mirrorOverrides: { id: string; name: string },
+): [PatternDefinition, PatternDefinition] {
+  return [
+    { ...baseMeta, generator: () => baseActions },
+    { ...baseMeta, ...mirrorOverrides, generator: () => mirrorActions(baseActions) },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Complete pattern library (36+ motion patterns, sorted by intensity)
+// ---------------------------------------------------------------------------
+
 export const PATTERN_DEFINITIONS: PatternDefinition[] = [
-  // LOW INTENSITY PATTERNS
-  {
-    id: 'gentle-wave-up',
-    name: 'Gentle Wave Up',
-    intensity: 'low',
-    tags: ['wave', 'smooth', 'rhythmic'],
-    durationMs: 23000,
-    generator: () => [
+  // ── LOW INTENSITY ────────────────────────────────────────────────────
+
+  ...patternPair(
+    { id: 'gentle-wave-up', name: 'Gentle Wave Up', intensity: 'low', tags: ['wave', 'smooth', 'rhythmic'], durationMs: 23000 },
+    [
       { pos: 0, at: 0 },
       { pos: 20, at: 3000 },
       { pos: 15, at: 5000 },
@@ -70,33 +107,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 70, at: 20000 },
       { pos: 100, at: 23000 },
     ],
-  },
-  {
-    id: 'gentle-wave-down',
-    name: 'Gentle Wave Down',
-    intensity: 'low',
-    tags: ['wave', 'smooth', 'rhythmic'],
-    durationMs: 23000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 80, at: 3000 },
-      { pos: 85, at: 5000 },
-      { pos: 65, at: 8000 },
-      { pos: 70, at: 10000 },
-      { pos: 45, at: 13000 },
-      { pos: 50, at: 15000 },
-      { pos: 25, at: 18000 },
-      { pos: 30, at: 20000 },
-      { pos: 0, at: 23000 },
-    ],
-  },
-  {
-    id: 'gradual-climb-up',
-    name: 'Gradual Climb Up',
-    intensity: 'low',
-    tags: ['gradual', 'smooth'],
-    durationMs: 30000,
-    generator: () => [
+    { id: 'gentle-wave-down', name: 'Gentle Wave Down' },
+  ),
+
+  ...patternPair(
+    { id: 'gradual-climb-up', name: 'Gradual Climb Up', intensity: 'low', tags: ['gradual', 'smooth'], durationMs: 30000 },
+    [
       { pos: 0, at: 0 },
       { pos: 5, at: 3000 },
       { pos: 10, at: 6000 },
@@ -109,131 +125,30 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 95, at: 27000 },
       { pos: 100, at: 30000 },
     ],
-  },
-  {
-    id: 'gradual-descent-down',
-    name: 'Gradual Descent Down',
-    intensity: 'low',
-    tags: ['gradual', 'smooth'],
-    durationMs: 30000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 95, at: 3000 },
-      { pos: 90, at: 6000 },
-      { pos: 80, at: 9000 },
-      { pos: 70, at: 12000 },
-      { pos: 55, at: 15000 },
-      { pos: 40, at: 18000 },
-      { pos: 25, at: 21000 },
-      { pos: 15, at: 24000 },
-      { pos: 5, at: 27000 },
-      { pos: 0, at: 30000 },
-    ],
-  },
-  {
-    id: 'ramp-up-slow',
-    name: 'Ramp Up Slow',
-    intensity: 'low',
-    tags: ['ramp', 'smooth', 'gradual'],
-    durationMs: 20000,
-    generator: () => [
-      { pos: 0, at: 0 },
-      { pos: 10, at: 2000 },
-      { pos: 20, at: 4000 },
-      { pos: 30, at: 6000 },
-      { pos: 40, at: 8000 },
-      { pos: 50, at: 10000 },
-      { pos: 60, at: 12000 },
-      { pos: 70, at: 14000 },
-      { pos: 80, at: 16000 },
-      { pos: 90, at: 18000 },
-      { pos: 100, at: 20000 },
-    ],
-  },
-  {
-    id: 'ramp-down-slow',
-    name: 'Ramp Down Slow',
-    intensity: 'low',
-    tags: ['ramp', 'smooth', 'gradual'],
-    durationMs: 20000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 90, at: 2000 },
-      { pos: 80, at: 4000 },
-      { pos: 70, at: 6000 },
-      { pos: 60, at: 8000 },
-      { pos: 50, at: 10000 },
-      { pos: 40, at: 12000 },
-      { pos: 30, at: 14000 },
-      { pos: 20, at: 16000 },
-      { pos: 10, at: 18000 },
-      { pos: 0, at: 20000 },
-    ],
-  },
-  {
-    id: 'incremental-up-slow',
-    name: 'Incremental Up Slow',
-    intensity: 'low',
-    tags: ['incremental', 'stepped'],
-    durationMs: 10000,
-    generator: () => [
-      { pos: 0, at: 0 },
-      { pos: 10, at: 1000 },
-      { pos: 20, at: 2000 },
-      { pos: 30, at: 3000 },
-      { pos: 40, at: 4000 },
-      { pos: 50, at: 5000 },
-      { pos: 60, at: 6000 },
-      { pos: 70, at: 7000 },
-      { pos: 80, at: 8000 },
-      { pos: 90, at: 9000 },
-      { pos: 100, at: 10000 },
-    ],
-  },
-  {
-    id: 'incremental-down-slow',
-    name: 'Incremental Down Slow',
-    intensity: 'low',
-    tags: ['incremental', 'stepped'],
-    durationMs: 10000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 90, at: 1000 },
-      { pos: 80, at: 2000 },
-      { pos: 70, at: 3000 },
-      { pos: 60, at: 4000 },
-      { pos: 50, at: 5000 },
-      { pos: 40, at: 6000 },
-      { pos: 30, at: 7000 },
-      { pos: 20, at: 8000 },
-      { pos: 10, at: 9000 },
-      { pos: 0, at: 10000 },
-    ],
-  },
-  {
-    id: 'direct-up-8s',
-    name: 'Direct Up 8s',
-    intensity: 'low',
-    tags: ['direct', 'smooth'],
-    durationMs: 8000,
-    generator: () => [
-      { pos: 0, at: 0 },
-      { pos: 100, at: 8000 },
-    ],
-  },
-  {
-    id: 'direct-down-8s',
-    name: 'Direct Down 8s',
-    intensity: 'low',
-    tags: ['direct', 'smooth'],
-    durationMs: 8000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 0, at: 8000 },
-    ],
-  },
+    { id: 'gradual-descent-down', name: 'Gradual Descent Down' },
+  ),
 
-  // MEDIUM INTENSITY PATTERNS
+  ...patternPair(
+    { id: 'ramp-up-slow', name: 'Ramp Up Slow', intensity: 'low', tags: ['ramp', 'smooth', 'gradual'], durationMs: 20000 },
+    linearRamp(10, 20000),
+    { id: 'ramp-down-slow', name: 'Ramp Down Slow' },
+  ),
+
+  ...patternPair(
+    { id: 'incremental-up-slow', name: 'Incremental Up Slow', intensity: 'low', tags: ['incremental', 'stepped'], durationMs: 10000 },
+    linearRamp(10, 10000),
+    { id: 'incremental-down-slow', name: 'Incremental Down Slow' },
+  ),
+
+  ...patternPair(
+    { id: 'direct-up-8s', name: 'Direct Up 8s', intensity: 'low', tags: ['direct', 'smooth'], durationMs: 8000 },
+    linearRamp(1, 8000),
+    { id: 'direct-down-8s', name: 'Direct Down 8s' },
+  ),
+
+  // ── MEDIUM INTENSITY ─────────────────────────────────────────────────
+
+  // Standalone pair — different shapes, not mirrors of each other
   {
     id: 'wave-up-slow',
     name: 'Wave Up Slow',
@@ -276,13 +191,10 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 50, at: 23000 },
     ],
   },
-  {
-    id: 'double-wave-up',
-    name: 'Double Wave Up',
-    intensity: 'medium',
-    tags: ['wave', 'rhythmic'],
-    durationMs: 20000,
-    generator: () => [
+
+  ...patternPair(
+    { id: 'double-wave-up', name: 'Double Wave Up', intensity: 'medium', tags: ['wave', 'rhythmic'], durationMs: 20000 },
+    [
       { pos: 0, at: 0 },
       { pos: 50, at: 4000 },
       { pos: 20, at: 8000 },
@@ -290,29 +202,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 40, at: 16000 },
       { pos: 100, at: 20000 },
     ],
-  },
-  {
-    id: 'double-wave-down',
-    name: 'Double Wave Down',
-    intensity: 'medium',
-    tags: ['wave', 'rhythmic'],
-    durationMs: 20000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 50, at: 4000 },
-      { pos: 80, at: 8000 },
-      { pos: 30, at: 12000 },
-      { pos: 60, at: 16000 },
-      { pos: 0, at: 20000 },
-    ],
-  },
-  {
-    id: 'plateau-up',
-    name: 'Plateau Up',
-    intensity: 'medium',
-    tags: ['plateau', 'smooth'],
-    durationMs: 21000,
-    generator: () => [
+    { id: 'double-wave-down', name: 'Double Wave Down' },
+  ),
+
+  ...patternPair(
+    { id: 'plateau-up', name: 'Plateau Up', intensity: 'medium', tags: ['plateau', 'smooth'], durationMs: 21000 },
+    [
       { pos: 0, at: 0 },
       { pos: 25, at: 3000 },
       { pos: 25, at: 6000 },
@@ -322,31 +217,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 75, at: 18000 },
       { pos: 100, at: 21000 },
     ],
-  },
-  {
-    id: 'plateau-down',
-    name: 'Plateau Down',
-    intensity: 'medium',
-    tags: ['plateau', 'smooth'],
-    durationMs: 21000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 75, at: 3000 },
-      { pos: 75, at: 6000 },
-      { pos: 50, at: 9000 },
-      { pos: 50, at: 12000 },
-      { pos: 25, at: 15000 },
-      { pos: 25, at: 18000 },
-      { pos: 0, at: 21000 },
-    ],
-  },
-  {
-    id: 'stepped-up',
-    name: 'Stepped Up',
-    intensity: 'medium',
-    tags: ['stepped'],
-    durationMs: 19000,
-    generator: () => [
+    { id: 'plateau-down', name: 'Plateau Down' },
+  ),
+
+  ...patternPair(
+    { id: 'stepped-up', name: 'Stepped Up', intensity: 'medium', tags: ['stepped'], durationMs: 19000 },
+    [
       { pos: 0, at: 0 },
       { pos: 20, at: 3000 },
       { pos: 20, at: 4000 },
@@ -358,33 +234,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 80, at: 16000 },
       { pos: 100, at: 19000 },
     ],
-  },
-  {
-    id: 'stepped-down',
-    name: 'Stepped Down',
-    intensity: 'medium',
-    tags: ['stepped'],
-    durationMs: 19000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 80, at: 3000 },
-      { pos: 80, at: 4000 },
-      { pos: 60, at: 7000 },
-      { pos: 60, at: 8000 },
-      { pos: 40, at: 11000 },
-      { pos: 40, at: 12000 },
-      { pos: 20, at: 15000 },
-      { pos: 20, at: 16000 },
-      { pos: 0, at: 19000 },
-    ],
-  },
-  {
-    id: 'bounce-up',
-    name: 'Bounce Up',
-    intensity: 'medium',
-    tags: ['bounce', 'rhythmic'],
-    durationMs: 18000,
-    generator: () => [
+    { id: 'stepped-down', name: 'Stepped Down' },
+  ),
+
+  ...patternPair(
+    { id: 'bounce-up', name: 'Bounce Up', intensity: 'medium', tags: ['bounce', 'rhythmic'], durationMs: 18000 },
+    [
       { pos: 0, at: 0 },
       { pos: 30, at: 3000 },
       { pos: 10, at: 6000 },
@@ -393,30 +248,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 80, at: 15000 },
       { pos: 100, at: 18000 },
     ],
-  },
-  {
-    id: 'bounce-down',
-    name: 'Bounce Down',
-    intensity: 'medium',
-    tags: ['bounce', 'rhythmic'],
-    durationMs: 18000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 70, at: 3000 },
-      { pos: 90, at: 6000 },
-      { pos: 60, at: 9000 },
-      { pos: 40, at: 12000 },
-      { pos: 20, at: 15000 },
-      { pos: 0, at: 18000 },
-    ],
-  },
-  {
-    id: 'peak-valley-down',
-    name: 'Peak Valley Down',
-    intensity: 'medium',
-    tags: ['wave', 'rhythmic'],
-    durationMs: 21000,
-    generator: () => [
+    { id: 'bounce-down', name: 'Bounce Down' },
+  ),
+
+  ...patternPair(
+    { id: 'peak-valley-down', name: 'Peak Valley Down', intensity: 'medium', tags: ['wave', 'rhythmic'], durationMs: 21000 },
+    [
       { pos: 100, at: 0 },
       { pos: 95, at: 3000 },
       { pos: 90, at: 6000 },
@@ -426,33 +263,14 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 15, at: 18000 },
       { pos: 0, at: 21000 },
     ],
-  },
-  {
-    id: 'valley-peak-up',
-    name: 'Valley Peak Up',
-    intensity: 'medium',
-    tags: ['wave', 'rhythmic'],
-    durationMs: 21000,
-    generator: () => [
-      { pos: 0, at: 0 },
-      { pos: 5, at: 3000 },
-      { pos: 10, at: 6000 },
-      { pos: 15, at: 9000 },
-      { pos: 40, at: 12000 },
-      { pos: 65, at: 15000 },
-      { pos: 85, at: 18000 },
-      { pos: 100, at: 21000 },
-    ],
-  },
+    { id: 'valley-peak-up', name: 'Valley Peak Up' },
+  ),
 
-  // HIGH INTENSITY PATTERNS
-  {
-    id: 'surge-up',
-    name: 'Surge Up',
-    intensity: 'high',
-    tags: ['surge', 'pulse'],
-    durationMs: 14000,
-    generator: () => [
+  // ── HIGH INTENSITY ───────────────────────────────────────────────────
+
+  ...patternPair(
+    { id: 'surge-up', name: 'Surge Up', intensity: 'high', tags: ['surge', 'pulse'], durationMs: 14000 },
+    [
       { pos: 0, at: 0 },
       { pos: 0, at: 2000 },
       { pos: 35, at: 4000 },
@@ -461,30 +279,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 65, at: 12000 },
       { pos: 100, at: 14000 },
     ],
-  },
-  {
-    id: 'surge-down',
-    name: 'Surge Down',
-    intensity: 'high',
-    tags: ['surge', 'pulse'],
-    durationMs: 14000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 100, at: 2000 },
-      { pos: 65, at: 4000 },
-      { pos: 65, at: 7000 },
-      { pos: 35, at: 9000 },
-      { pos: 35, at: 12000 },
-      { pos: 0, at: 14000 },
-    ],
-  },
-  {
-    id: 'stutter-up',
-    name: 'Stutter Up',
-    intensity: 'high',
-    tags: ['stutter', 'rhythmic'],
-    durationMs: 20000,
-    generator: () => [
+    { id: 'surge-down', name: 'Surge Down' },
+  ),
+
+  ...patternPair(
+    { id: 'stutter-up', name: 'Stutter Up', intensity: 'high', tags: ['stutter', 'rhythmic'], durationMs: 20000 },
+    [
       { pos: 0, at: 0 },
       { pos: 15, at: 2000 },
       { pos: 10, at: 3000 },
@@ -500,37 +300,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 85, at: 18000 },
       { pos: 100, at: 20000 },
     ],
-  },
-  {
-    id: 'stutter-down',
-    name: 'Stutter Down',
-    intensity: 'high',
-    tags: ['stutter', 'rhythmic'],
-    durationMs: 20000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 85, at: 2000 },
-      { pos: 90, at: 3000 },
-      { pos: 70, at: 5000 },
-      { pos: 75, at: 6000 },
-      { pos: 55, at: 8000 },
-      { pos: 60, at: 9000 },
-      { pos: 40, at: 11000 },
-      { pos: 45, at: 12000 },
-      { pos: 25, at: 14000 },
-      { pos: 30, at: 15000 },
-      { pos: 10, at: 17000 },
-      { pos: 15, at: 18000 },
-      { pos: 0, at: 20000 },
-    ],
-  },
-  {
-    id: 'zigzag-up',
-    name: 'Zigzag Up',
-    intensity: 'high',
-    tags: ['zigzag', 'rhythmic'],
-    durationMs: 17000,
-    generator: () => [
+    { id: 'stutter-down', name: 'Stutter Down' },
+  ),
+
+  ...patternPair(
+    { id: 'zigzag-up', name: 'Zigzag Up', intensity: 'high', tags: ['zigzag', 'rhythmic'], durationMs: 17000 },
+    [
       { pos: 0, at: 0 },
       { pos: 20, at: 2000 },
       { pos: 15, at: 3000 },
@@ -544,35 +319,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 75, at: 15000 },
       { pos: 100, at: 17000 },
     ],
-  },
-  {
-    id: 'zigzag-down',
-    name: 'Zigzag Down',
-    intensity: 'high',
-    tags: ['zigzag', 'rhythmic'],
-    durationMs: 17000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 80, at: 2000 },
-      { pos: 85, at: 3000 },
-      { pos: 65, at: 5000 },
-      { pos: 70, at: 6000 },
-      { pos: 50, at: 8000 },
-      { pos: 55, at: 9000 },
-      { pos: 35, at: 11000 },
-      { pos: 40, at: 12000 },
-      { pos: 20, at: 14000 },
-      { pos: 25, at: 15000 },
-      { pos: 0, at: 17000 },
-    ],
-  },
-  {
-    id: 'accelerating-up',
-    name: 'Accelerating Up',
-    intensity: 'high',
-    tags: ['accelerating', 'rhythmic'],
-    durationMs: 13000,
-    generator: () => [
+    { id: 'zigzag-down', name: 'Zigzag Down' },
+  ),
+
+  ...patternPair(
+    { id: 'accelerating-up', name: 'Accelerating Up', intensity: 'high', tags: ['accelerating', 'rhythmic'], durationMs: 13000 },
+    [
       { pos: 0, at: 0 },
       { pos: 10, at: 4000 },
       { pos: 25, at: 7000 },
@@ -580,29 +332,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 70, at: 11500 },
       { pos: 100, at: 13000 },
     ],
-  },
-  {
-    id: 'accelerating-down',
-    name: 'Accelerating Down',
-    intensity: 'high',
-    tags: ['accelerating', 'rhythmic'],
-    durationMs: 13000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 90, at: 4000 },
-      { pos: 75, at: 7000 },
-      { pos: 55, at: 9500 },
-      { pos: 30, at: 11500 },
-      { pos: 0, at: 13000 },
-    ],
-  },
-  {
-    id: 'decelerating-up',
-    name: 'Decelerating Up',
-    intensity: 'high',
-    tags: ['decelerating', 'rhythmic'],
-    durationMs: 17000,
-    generator: () => [
+    { id: 'accelerating-down', name: 'Accelerating Down' },
+  ),
+
+  ...patternPair(
+    { id: 'decelerating-up', name: 'Decelerating Up', intensity: 'high', tags: ['decelerating', 'rhythmic'], durationMs: 17000 },
+    [
       { pos: 0, at: 0 },
       { pos: 30, at: 2000 },
       { pos: 55, at: 4000 },
@@ -611,30 +346,12 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 90, at: 13000 },
       { pos: 100, at: 17000 },
     ],
-  },
-  {
-    id: 'decelerating-down',
-    name: 'Decelerating Down',
-    intensity: 'high',
-    tags: ['decelerating', 'rhythmic'],
-    durationMs: 17000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 70, at: 2000 },
-      { pos: 45, at: 4000 },
-      { pos: 30, at: 6500 },
-      { pos: 20, at: 9500 },
-      { pos: 10, at: 13000 },
-      { pos: 0, at: 17000 },
-    ],
-  },
-  {
-    id: 'triple-wave-up',
-    name: 'Triple Wave Up',
-    intensity: 'high',
-    tags: ['wave', 'rhythmic'],
-    durationMs: 21000,
-    generator: () => [
+    { id: 'decelerating-down', name: 'Decelerating Down' },
+  ),
+
+  ...patternPair(
+    { id: 'triple-wave-up', name: 'Triple Wave Up', intensity: 'high', tags: ['wave', 'rhythmic'], durationMs: 21000 },
+    [
       { pos: 0, at: 0 },
       { pos: 35, at: 3000 },
       { pos: 15, at: 6000 },
@@ -644,26 +361,11 @@ export const PATTERN_DEFINITIONS: PatternDefinition[] = [
       { pos: 55, at: 18000 },
       { pos: 100, at: 21000 },
     ],
-  },
-  {
-    id: 'triple-wave-down',
-    name: 'Triple Wave Down',
-    intensity: 'high',
-    tags: ['wave', 'rhythmic'],
-    durationMs: 21000,
-    generator: () => [
-      { pos: 100, at: 0 },
-      { pos: 65, at: 3000 },
-      { pos: 85, at: 6000 },
-      { pos: 45, at: 9000 },
-      { pos: 65, at: 12000 },
-      { pos: 25, at: 15000 },
-      { pos: 45, at: 18000 },
-      { pos: 0, at: 21000 },
-    ],
-  },
+    { id: 'triple-wave-down', name: 'Triple Wave Down' },
+  ),
 
-  // GENERATED PATTERNS (not from files)
+  // ── GENERATED PATTERNS ───────────────────────────────────────────────
+
   {
     id: 'slow-sine-wave',
     name: 'Slow Sine Wave',


### PR DESCRIPTION
## Summary
- Added 3 helper functions to eliminate pattern definition duplication:
  - **`mirrorActions()`** — flips pos values (100 − pos) to auto-generate directional mirrors
  - **`linearRamp(steps, durationMs)`** — generates evenly-spaced ramp patterns parametrically
  - **`patternPair()`** — defines base + mirror pattern from a single action array
- 15 up/down pairs now defined once (mirror auto-generated from base)
- 3 ramp-style patterns (ramp, incremental, direct) use `linearRamp()` instead of hand-coded arrays
- **703 → 405 lines (-42%)**
- Same 36 patterns, same IDs, same order — zero behavioral change

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 35 existing tests pass (`npx vitest run`)
- [x] Verified pattern count is 36 (unchanged)
- [x] Verified mirror correctness (every mirrored pos = 100 − original pos)
- [x] Verified linearRamp output matches original hand-coded arrays
- [ ] Manual: pattern library shows all patterns with correct previews
- [ ] Manual: inserting mirrored patterns (e.g., Gentle Wave Down) produces correct motion
- [ ] Manual: ramp/incremental/direct patterns render and insert correctly