### PR TITLE
docs: correct privacy claims for Autoblow cloud API

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-A privacy-first web interface for the Autoblow AI Ultra device that provides video-synced funscript playback, visual motion pattern editing, and real-time device testing. Users can load local video files, sync them with funscripts, visually preview and edit motion patterns on a timeline, and test motions in real-time on their device - all without cloud services or uploads.
+A privacy-first web interface for the Autoblow AI Ultra device that provides video-synced funscript playback, visual motion pattern editing, a persistent content library, playlist management, embedded video support, and real-time device testing. All content processing and storage is local — the only external dependency is Autoblow's cloud API (`latency.autoblowapi.com` + cluster endpoints) required by the SDK for device communication. Deployable via Docker with security hardening.
 
 ## Core Value
 
@@ -26,81 +26,67 @@ Smooth, privacy-preserving funscript playback synced with local video content.
 - ✓ Manual device controls for testing individual motions — v1.0
 - ✓ Visual feedback showing current playback position on timeline — v1.0
 - ✓ Pause/resume/seek controls affecting both video and device sync — v1.0
+- ✓ Script smoother to remove noisy short movements from funscripts — v1.1
+- ✓ Pattern editor for creating editable copies of presets with duration/motion controls — v1.1
+- ✓ Pattern builder with step-based waypoint UI for custom pattern creation — v1.1
+- ✓ Video/script library for persistent storage of played content — v1.1
+- ✓ Playlist system with sequential playback and per-video funscript loading — v1.1
+- ✓ Third-party video embedding with API-based funscript sync — v1.1
+- ✓ Security hardening: localhost-only + Docker deployment — v1.1
+- ✓ SQLite backend for persistent storage (replacing IndexedDB) — v1.1
 
 ### Active
 
-<!-- v1.1 scope -->
-- [ ] Script smoother to remove noisy short movements from funscripts
-- [ ] Pattern editor for creating editable copies of presets with duration/motion controls
-- [ ] Pattern builder with step-based waypoint UI for custom pattern creation
-- [ ] Video/script library for persistent storage of played content
-- [ ] Playlist system with sequential playback and per-video funscript loading
-- [ ] Third-party video embedding with API-based funscript sync
-- [ ] Security hardening: localhost-only + Docker host access
-- [ ] SQLite backend for persistent storage (replacing IndexedDB)
+(None — planning next milestone)
 
 ### Out of Scope
 
-- Cloud storage or streaming — Privacy is core, everything stays local
+- Cloud storage or streaming — Privacy is core, content stays local (device control requires Autoblow cloud API)
 - User accounts or authentication — Single-user, local tool
-- Mobile app — Web-based only for v1
-- Multi-device support — Autoblow AI Ultra only for v1
+- Mobile app — Web-based only
+- Multi-device support — Autoblow AI Ultra only
 - Social/sharing features — Private tool for personal use
 - Pattern marketplace or community features — Privacy-focused, no external connections
 - Third-party video sync without embed API — Unreliable without player time access
-- AI/ML-based script generation — Deterministic algorithms only for v1.1
-
-## Current Milestone: v1.1 Content Library & Advanced Editing
-
-**Goal:** Transform the tool from a single-session player into a persistent content library with advanced pattern editing, playlist management, and third-party video support.
-
-**Target features:**
-- Script smoother (algorithm from user-provided examples)
-- Pattern editor (edit copies of presets, duration/motion controls, device demo with loop smoothing)
-- Pattern builder (step-based waypoint UI, device loop testing)
-- Video/script library (persistent storage, SQLite)
-- Playlist (sequential playback, per-video scripts, saved to library)
-- Third-party video embedding (Pornhub etc., API-only sync, embed links in library)
-- Security (localhost-only, Docker host access)
-- SQLite migration (replace IndexedDB)
+- AI/ML-based script generation — Deterministic algorithms only
+- Video storage in browser — Causes quota errors (videos are 100MB-5GB)
+- Site-specific video scraping — Copyright/legal liability
 
 ## Context
 
-**Current State (v1.0 shipped):**
-- 8,566 LOC TypeScript/TSX across 92 files
-- Tech stack: Vite + React + TypeScript, shadcn/ui, Tailwind CSS, Dexie (IndexedDB), autoblow-js-sdk
-- 4 pages: Video Sync, Manual Control, Device Log, Pattern Library
-- Canvas-based timeline with editing, validation, and pattern insertion
-- 36 motion patterns with animated previews and search/filter
-
-**Existing Assets:**
-- 35+ pre-built motion patterns in motions/ directory
-- Funscript format: JSON with `version`, `inverted`, `range`, and `actions` array containing `{pos, at}` pairs
+**Current State (v1.1 shipped):**
+- 16,723 LOC TypeScript/TSX across ~100+ files
+- Tech stack: Vite + React 19 + TypeScript, Tailwind CSS, Express + SQLite (better-sqlite3), react-player, dnd-kit, helmet
+- 6 pages: Library, Video Sync, Manual Control, Pattern Library, Playlists, Device Log
+- Canvas-based timeline with editing, validation, smoothing, and pattern insertion
+- 36+ motion patterns with animated previews, search/filter, custom editing, and waypoint builder
+- Content library with SQLite persistence, playlist management, embedded video support
+- Docker deployment with nginx reverse proxy and security headers
+- AES-GCM encrypted device token storage
 
 **Technical Environment:**
 - Target device: Autoblow AI Ultra
-- SDK: autoblow-js-sdk (https://developers.autoblow.com/guides/autoblow-js-sdk/)
-
-**User Intent:**
-- Personal use for testing and enjoying content
-- Privacy is paramount - no uploads, tracking, or external services
-- Streamline workflow for testing existing patterns and creating custom synced content
+- SDK: @xsense/autoblow-sdk (https://developers.autoblow.com/guides/autoblow-js-sdk/)
+  - Calls `latency.autoblowapi.com` for device discovery and cluster assignment
+  - All device commands (move, sync-script, etc.) routed through assigned cluster endpoint
+- Backend: Express on port 3001, Vite on port 5173
+- Database: SQLite with WAL mode via better-sqlite3
 
 ## Constraints
 
-- **Privacy**: All local processing, no cloud services, no uploads, no tracking, no analytics
+- **Privacy**: All local processing, no uploads, no tracking, no analytics. The only external network call is to Autoblow's cloud API (via `@xsense/autoblow-sdk`) for device discovery and command relay
 - **Tech Stack**: Web-based (browser), must use autoblow-js-sdk for device communication
 - **UI/UX**: Dark/modern theme, visual timeline editor with graph-based motion display, simple and intuitive controls
 - **File Format**: Must support standard funscript format (JSON with actions array)
-- **Device**: Autoblow AI Ultra only (other devices out of scope for v1)
+- **Device**: Autoblow AI Ultra only
 
 ## Key Decisions
 
 | Decision | Rationale | Outcome |
 |----------|-----------|---------|
-| Privacy-first local architecture | User's core requirement - no cloud, no uploads, complete privacy | ✓ Good |
+| Privacy-first local architecture | User's core requirement - no content uploads, no tracking; device control requires Autoblow cloud API | ✓ Good |
 | Visual timeline editor | Inspired by funscript.io - intuitive way to see and edit motion patterns over time | ✓ Good |
-| Web-based interface | Cross-platform, no installation, works on any device with browser and autoblow-js-sdk support | ✓ Good |
+| Web-based interface | Cross-platform, no installation, works on any device with browser | ✓ Good |
 | Canvas API for timeline rendering | 10-100x faster than SVG for large funscript datasets | ✓ Good |
 | Video element as master clock | Device follows video timing, single source of truth for sync | ✓ Good |
 | Snapshot-based undo/redo | Simpler than command pattern, sufficient for expected edit volumes | ✓ Good |
@@ -108,9 +94,16 @@ Smooth, privacy-preserving funscript playback synced with local video content.
 | Pure function pattern generators | No React dependencies, testable and composable | ✓ Good |
 | Presentation components pattern | State lifted to App.tsx, pages are pure UI — clean separation | ✓ Good |
 | AND-logic pattern filtering | All filters must match simultaneously — intuitive UX | ✓ Good |
-
-| SQLite for persistent storage | IndexedDB unreliable across browser clears; SQLite more robust for library/playlist data | — Pending |
-| API-only third-party sync | Embed APIs vary; only sync where player exposes time API | — Pending |
+| SQLite for persistent storage | IndexedDB unreliable across browser clears; SQLite more robust | ✓ Good |
+| Layered architecture (repo-service-controller) | SOLID principles, testable, maintainable backend | ✓ Good |
+| Vitest for testing | Vite-native, fast execution, TypeScript support | ✓ Good |
+| Preview-without-mutation for smoothing | Prevents undo stack pollution during preview | ✓ Good |
+| Multiplicative duration scaling | Preserves proportional timing relationships between actions | ✓ Good |
+| ReactPlayer for embeds | Unified API across YouTube, Vimeo, and other platforms | ✓ Good |
+| Manual sync for unsupported platforms | Graceful degradation when embed API unavailable | ✓ Good |
+| Helmet CSP in production only | Prevents breaking Vite HMR in development | ✓ Good |
+| AES-GCM token encryption | Protects device token at rest against generic XSS scrapers | ✓ Good |
+| Docker multi-stage builds | Minimal image sizes, Alpine base for production | ✓ Good |
 
 ---
-*Last updated: 2026-02-08 after v1.1 milestone started*
+*Last updated: 2026-02-09 after v1.1 milestone*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,26 +2,25 @@
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-02-08)
+See: .planning/PROJECT.md (updated 2026-02-09)
 
 **Core value:** Smooth, privacy-preserving funscript playback synced with local video content.
-**Current focus:** Phase 15 - Embedded Video (v1.1) — IN PROGRESS
+**Current focus:** v1.0 + v1.1 shipped — ready for next milestone
 
 ## Current Position
 
-Phase: 15 of 16 (Embedded Video)
-Plan: 2 of 2 complete
-Status: Phase complete
-Last activity: 2026-02-09 - Completed 15-02-PLAN.md (Embed Integration)
+Milestone: v1.1 Content Library & Advanced Editing — SHIPPED 2026-02-09
+Status: Both milestones complete, archived to .planning/milestones/
+Last activity: 2026-02-09 - Architecture analysis document updated
 
-Progress: [████████████████░░░░] 96% (15/16 phases complete, v1.0 shipped, Phase 15: 2/2 ✓)
+Progress: [████████████████████] 100% (v1.0 + v1.1 shipped, 16 phases, 37 plans)
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 35
-- Average duration: 4.3 minutes
-- Total execution time: ~2.79 hours
+- Total plans completed: 37
+- Average duration: 4.1 minutes
+- Total execution time: ~2.87 hours
 
 **By Phase:**
 
@@ -42,55 +41,19 @@ Progress: [████████████████░░░░] 96% (15
 | 13 | 2 | 5 min | 2.5 min |
 | 14 | 4 | 11.5 min | 2.9 min |
 | 15 | 2 | 13 min | 6.5 min |
-
-**Recent Trend:**
-- Last 5 plans: 3.0, 3.0, 1.0, 7.0, 6.0 min (avg: 4.0 min)
-- Trend: Stable
-
-*Updated after each plan completion*
+| 16 | 2 | 5.3 min | 2.65 min |
 
 ## Accumulated Context
 
-### Decisions
+### Key Decisions
 
-All v1.0 decisions archived in PROJECT.md Key Decisions table.
+All decisions archived in PROJECT.md Key Decisions table and milestone archives:
+- .planning/milestones/v1.0-ROADMAP.md
+- .planning/milestones/v1.1-ROADMAP.md
 
-**v1.1 decisions (Phases 10-12):**
+### External Dependencies
 
-| Decision | Rationale | Plan | Status |
-|----------|-----------|------|--------|
-| SQLite with WAL mode | Better concurrency, persistent storage more reliable than IndexedDB | 10-01 | ✓ Implemented |
-| Layered architecture (repository-service-controller) | SOLID principles, testable, maintainable | 10-01 | ✓ Implemented |
-| Vite port 5173, Express port 3001 | Standard convention, avoids confusion | 10-01 | ✓ Implemented |
-| Manual upsert logic for videoName | SQLite ON CONFLICT requires unique constraint | 10-01 | ✓ Implemented |
-| Debounce auto-save with 2-second delay | Prevents excessive API calls during active editing | 10-02 | ✓ Implemented |
-| Silent return on duplicate migration | True idempotency - safe to call multiple times | 10-02 | ✓ Implemented |
-| Library tab as default landing page | Content-centric workflow - browse saved content first | 10-03 | ✓ Implemented |
-| Client-side filtering after API fetch | Simple implementation, low latency for filter changes | 10-03 | ✓ Implemented |
-| loadFunscriptFromData method added | Load funscript from JSON string, not File object | 10-03 | ✓ Implemented |
-| Vitest as test framework | Vite-native, fast execution, TypeScript support | 11-01 | ✓ Implemented |
-| Moderate intensity as discrete range (34-66) | Ensures case study defaults map exactly to intensity 50 | 11-01 | ✓ Implemented |
-| Time-based oscillation thinning | Simpler than direction-aware alternation, achieves 450ms target | 11-01 | ✓ Implemented |
-| Preview-without-mutation pattern for useSmoothing | Prevents undo stack pollution by never calling setActions during preview | 11-02 | ✓ Implemented |
-| 300ms debounce for intensity slider auto-preview | Balances responsiveness with performance for large scripts | 11-02 | ✓ Implemented |
-| PRAGMA table_info for idempotent migrations | Allows safe re-running without ALTER TABLE errors | 12-01 | ✓ Implemented |
-| COALESCE for partial PATCH updates | Updates only provided fields, preserves existing values | 12-01 | ✓ Implemented |
-| Multiplicative duration scaling | Preserves proportional timing relationships between actions | 12-01 | ✓ Implemented |
-| Preserve endpoints during intensity adjustment | Maintains pattern start/end positions for smooth transitions | 12-01 | ✓ Implemented |
-| No UNIQUE constraint on (playlist_id, position) | Temporary duplicates occur during reorder transactions; application logic manages uniqueness | 14-01 | ✓ Implemented |
-| Position compaction on item removal | Maintains contiguous positions for simpler UI logic and prevents gaps | 14-01 | ✓ Implemented |
-| Optimistic reorder updates with revert on error | Provides immediate UI feedback for drag-and-drop while maintaining consistency with backend state | 14-02 | ✓ Implemented |
-| Filter library items to video-associated items only | Playlists are video-focused per research; prevents adding script-only items | 14-02 | ✓ Implemented |
-| Sequential advancement via video 'ended' event listener | Browser fires 'ended' event reliably when video completes, providing clean trigger for auto-advance | 14-03 | ✓ Implemented |
-| Preload next video in hidden document.createElement('video') element | Triggers browser buffering without polluting React component tree, simple cleanup via refs | 14-03 | ✓ Implemented |
-| Stop playlist on last video end (auto-exit mode) | Clean completion state prevents indefinite playlist mode after content ends | 14-03 | ✓ Implemented |
-| Parameter override pattern for stale closures | When setState and async call occur synchronously, pass fresh data as parameter to avoid closure capturing pre-render state | 14-04 | ✓ Implemented |
-| ReactPlayer.canPlay for platform detection | Static method determines platform support before rendering embed player | 15-01 | ✓ Implemented |
-| Hook interface parity for embed playback | useEmbedPlayback exports same interface as useVideoPlayback for drop-in replacement | 15-01 | ✓ Implemented |
-| 50ms manual sync step size | Balances precision with usability for timing adjustments on unsupported platforms | 15-01 | ✓ Implemented |
-
-**v1.1 architectural decisions pending:**
-- None
+- **Autoblow Cloud API** (required): `@xsense/autoblow-sdk` calls `latency.autoblowapi.com` for device discovery, then routes all device commands through assigned cluster endpoint. This is the only external network dependency.
 
 ### Pending Todos
 
@@ -98,36 +61,13 @@ None.
 
 ### Blockers/Concerns
 
-**Phase 10 (Backend Foundation):**
-- ~~Backend architecture requires Express + better-sqlite3 setup~~ ✓ Resolved (10-01)
-- ~~IndexedDB to SQLite migration must be idempotent and safe (no data loss)~~ ✓ Resolved (10-02)
-
-**Phase 11 (Script Smoothing):**
-- ✓ Resolved - Phase complete (smoothing engine + UI integration)
-
-**Phase 12 (Pattern Editing):**
-- ✓ Complete - pattern editor with canvas editing and custom pattern grid integration
-
-**Phase 13 (Pattern Builder):**
-- ✓ Complete - waypoint-based pattern builder with interactive canvas UI (13-01, 13-02)
-
-**Phase 14 (Playlist Management):**
-- ✓ Complete - playlist CRUD API with position management and cascade deletes (14-01)
-- ✓ Complete - playlist management UI with drag-and-drop editor (14-02)
-- ✓ Complete - playlist playback engine with sequential advancement and preloading (14-03)
-- ✓ Complete - UAT bug fix for stale closure preventing initial video/funscript load (14-04)
-- **Phase complete - UAT Issues 8 and 11 resolved, full playlist playback functional**
-
-**Phase 15 (Embedded Video):**
-- ✓ Foundation complete - platform detection, ReactPlayer wrapper, manual sync controls (15-01)
-- ✓ Integration complete - embed support wired into VideoPlayer, App.tsx, VideoSyncPage, LibraryPage (15-02)
-- **Phase complete - users can paste YouTube/Vimeo URLs, sync with funscripts, store in library**
+None — all phases complete, all blockers resolved.
 
 ## Session Continuity
 
 Last session: 2026-02-09
-Stopped at: Completed 15-02-PLAN.md (Embed Integration) - Phase 15 complete
-Resume file: Phase 16 planning pending
+Stopped at: Architecture analysis and planning doc updates
+Next action: `/gsd:new-milestone` to plan next version
 
 Config:
 {

--- a/autoblow-panel.arc.md
+++ b/autoblow-panel.arc.md
@@ -31,7 +31,7 @@
 
 ### Project Purpose
 
-**Autoblow Panel** is a local-first web application for controlling the Autoblow AI Ultra device. It provides video-device synchronization, funscript editing, pattern creation, playlist management, and manual device control — all running entirely on the user's machine with zero cloud services, uploads, or tracking.
+**Autoblow Panel** is a local-first web application for controlling the Autoblow AI Ultra device. It provides video-device synchronization, funscript editing, pattern creation, playlist management, and manual device control — all running on the user's machine with no uploads, tracking, or analytics. The only external dependency is Autoblow's cloud API (`latency.autoblowapi.com` + cluster endpoints), which the SDK requires for device discovery and command relay.
 
 ### Technology Stack
 
@@ -752,7 +752,7 @@ No LLM calls, no model inference, no training data.
 | Session state | IndexedDB (browser) | No (local only) |
 
 **Data NOT Collected:**
-- No cloud uploads
+- No cloud uploads (device commands routed through Autoblow cloud API by SDK — this is the only external dependency)
 - No user accounts or PII
 - No telemetry or analytics
 - No cookies or tracking


### PR DESCRIPTION
## Summary
- Corrected "zero cloud services" claims across planning docs and architecture document
- The `@xsense/autoblow-sdk` requires Autoblow's cloud API (`latency.autoblowapi.com` + cluster endpoints) for device discovery and command relay — this is the sole external network dependency
- Cleaned up STATE.md by removing stale phase-by-phase blocker history (all resolved)

## Files changed
- `.planning/PROJECT.md` — updated description, constraints, tech environment, key decisions
- `.planning/STATE.md` — streamlined; removed resolved blockers, added External Dependencies section
- `autoblow-panel.arc.md` — corrected project overview and privacy section

## Test plan
- [ ] Verify claims match SDK source (`node_modules/@xsense/autoblow-sdk/src/deviceInit.ts`)
- [ ] Confirm no other external network calls exist outside the SDK