### PR TITLE
feat: toggle video play/pause from device pause button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { useSyncPlayback } from '@/hooks/useSyncPlayback';
 import { useLibrary } from '@/hooks/useLibrary';
 import { usePlaylistManager } from '@/hooks/usePlaylistManager';
 import { usePlaylistPlayback } from '@/hooks/usePlaylistPlayback';
+import { useDeviceButtons } from '@/hooks/useDeviceButtons';
 import { mediaApi } from '@/lib/apiClient';
 import { captureVideoThumbnail } from '@/lib/thumbnailCapture';
 import { exportFunscript } from '@/lib/funscriptExport';
@@ -142,6 +143,9 @@ function AppContent() {
     clearVideo,
     clearFunscript,
   });
+
+  // Device button events (pause button toggles local video play/pause)
+  useDeviceButtons(ultra, videoRef, playback.isEmbed);
 
   // Handle session recovery hint on mount
   useEffect(() => {

--- a/src/hooks/useDeviceButtons.ts
+++ b/src/hooks/useDeviceButtons.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import type { Ultra } from '@xsense/autoblow-sdk';
+
+/**
+ * Listens for physical button presses on the Autoblow Ultra device
+ * and maps them to application actions.
+ *
+ * Currently handles the pause button — toggles play/pause on the
+ * local video element. Does nothing when no device is connected
+ * or when an embedded video is active (embeds lack direct element control).
+ */
+export function useDeviceButtons(
+  ultra: Ultra | null,
+  videoRef: React.RefObject<HTMLVideoElement | null>,
+  isEmbed: boolean,
+) {
+  useEffect(() => {
+    if (!ultra || isEmbed) return;
+
+    const handlePauseButton = () => {
+      const video = videoRef.current;
+      if (!video) return;
+
+      if (video.paused) {
+        video.play().catch(() => {
+          // Browser may block autoplay — ignore silently
+        });
+      } else {
+        video.pause();
+      }
+    };
+
+    ultra.deviceEvents.addEventListener('pause-button-pressed', handlePauseButton);
+
+    return () => {
+      ultra.deviceEvents.removeEventListener('pause-button-pressed', handlePauseButton);
+    };
+  }, [ultra, videoRef, isEmbed]);
+}


### PR DESCRIPTION
## Summary
- New `useDeviceButtons` hook listens for the Ultra's physical `pause-button-pressed` SSE event
- Toggles `video.play()`/`video.pause()` on the local HTML5 player
- Existing `useSyncPlayback` automatically handles device sync (script start/stop) via video element events
- Skipped for embedded videos — they lack direct element control

## Changes
- `src/hooks/useDeviceButtons.ts` — new hook (40 lines)
- `src/App.tsx` — import + one-line hook call

## Test plan
- [ ] Connect to Autoblow Ultra device
- [ ] Load a local video + funscript
- [ ] Start playback, press physical pause button → video and device should pause
- [ ] Press pause button again → video and device should resume
- [ ] Load an embedded video → pause button should have no effect (expected)
- [ ] Disconnect device → no errors, hook is a no-op