### PR TITLE
fix: restore New Script button and add demo to creation footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,7 @@ function AppContent() {
   const [scriptName, setScriptName] = useState<string>('');
 
   // Device state from context
-  const { ultra, addLog } = useDevice();
+  const { ultra, addLog, isDeviceConnected } = useDevice();
 
   // Library state
   const library = useLibrary();
@@ -531,6 +531,8 @@ function AppContent() {
           actions={editableActions}
           onClose={handleCloseCreation}
           onExport={handleExport}
+          ultra={ultra}
+          isDeviceConnected={isDeviceConnected}
         />
       )}
     </div>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -98,6 +98,20 @@ export function AppHeader({
         </span>
       </div>
 
+      {/* Center: New Script button */}
+      <div className="flex-1 flex justify-center">
+        <button
+          onClick={onNewScript}
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer ${
+            isCreationMode
+              ? 'bg-emerald-900/40 border border-emerald-700/50 text-emerald-400 hover:bg-emerald-900/60'
+              : 'bg-stone-800/60 border border-stone-700/50 text-stone-300 hover:bg-stone-700/60 hover:text-stone-100'
+          }`}
+        >
+          {isCreationMode ? 'Creating Script' : '+ New Script'}
+        </button>
+      </div>
+
       {/* Right: Connection controls */}
       <div className="flex items-center gap-3">
         {/* Connected indicator badge */}


### PR DESCRIPTION
## Summary
- Restored missing "+ New Script" button in AppHeader (lost during UI redesign PR #20)
- Added Demo button to CreationFooter that uploads the current script to the device with smooth looping, matching pattern library demo behavior
- Uses `useDemoLoop` + `createSmoothTransition` for seamless playback

## Files changed
- `src/components/layout/AppHeader.tsx` — restored center New Script button with stone/amber theme
- `src/components/layout/CreationFooter.tsx` — added demo playback with looping and smooth transitions
- `src/App.tsx` — pass `ultra` and `isDeviceConnected` props to CreationFooter

## Test plan
- [x] New Script button visible in header
- [x] Demo button visible in creation footer when device connected
- [x] Demo plays script on device with looping
- [x] Demo stops cleanly on button click or footer close