### PR TITLE
feat: add fullscreen button to video player

### DIFF
--- a/src/components/video-player/VideoControls.tsx
+++ b/src/components/video-player/VideoControls.tsx
@@ -7,6 +7,7 @@ interface VideoControlsProps {
   duration: number;
   onTogglePlayPause: () => void;
   onSeek: (time: number) => void;
+  onToggleFullscreen: () => void;
   error: string | null;
 }
 
@@ -20,6 +21,7 @@ export function VideoControls({
   duration,
   onTogglePlayPause,
   onSeek,
+  onToggleFullscreen,
   error,
 }: VideoControlsProps) {
   return (
@@ -48,6 +50,20 @@ export function VideoControls({
         <div className="text-sm text-stone-500 whitespace-nowrap min-w-[100px] text-right" style={{ fontFamily: 'var(--font-mono)' }}>
           {formatTime(currentTime)} / {formatTime(duration)}
         </div>
+
+        {/* Fullscreen Button */}
+        <button
+          onClick={onToggleFullscreen}
+          className="flex items-center justify-center w-8 h-8 rounded-md text-stone-400 hover:text-stone-200 hover:bg-stone-800 transition-colors"
+          aria-label="Toggle fullscreen"
+        >
+          <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+            <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+            <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+            <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+          </svg>
+        </button>
       </div>
     </div>
   );

--- a/src/components/video-player/VideoPlayer.tsx
+++ b/src/components/video-player/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { VideoControls } from './VideoControls';
 import { EmbedVideoPlayer } from './EmbedVideoPlayer';
 
@@ -52,6 +52,19 @@ export function VideoPlayer({
   onEmbedError,
   onEmbedEnded,
 }: VideoPlayerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const toggleFullscreen = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else {
+      el.requestFullscreen();
+    }
+  }, []);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -85,6 +98,10 @@ export function VideoPlayer({
           e.preventDefault();
           onSeek(Math.min(duration, currentTime + 5));
           break;
+        case 'f':
+          e.preventDefault();
+          toggleFullscreen();
+          break;
       }
     };
 
@@ -92,10 +109,10 @@ export function VideoPlayer({
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [onTogglePlayPause, onSeek, currentTime, duration]);
+  }, [onTogglePlayPause, onSeek, currentTime, duration, toggleFullscreen]);
 
   return (
-    <div className="rounded-lg overflow-hidden border border-stone-800">
+    <div ref={containerRef} className="rounded-lg overflow-hidden border border-stone-800 bg-black">
       {/* Conditional video element or embed player */}
       {isEmbed ? (
         <EmbedVideoPlayer
@@ -128,6 +145,7 @@ export function VideoPlayer({
           duration={duration}
           onTogglePlayPause={onTogglePlayPause}
           onSeek={onSeek}
+          onToggleFullscreen={toggleFullscreen}
           error={error}
         />
       )}


### PR DESCRIPTION
## Summary
- Added fullscreen toggle button to video controls (right of time display)
- Uses Fullscreen API on the player container so custom controls remain visible in fullscreen
- Added `f` keyboard shortcut for fullscreen toggle

## Files changed
- `src/components/video-player/VideoControls.tsx` — new fullscreen button with expand icon
- `src/components/video-player/VideoPlayer.tsx` — container ref, fullscreen toggle callback, `f` keyboard shortcut

## Test plan
- [x] Fullscreen button visible next to time display
- [x] Click toggles fullscreen with controls visible
- [x] Press `f` toggles fullscreen
- [x] Esc exits fullscreen (browser native)