### PR TITLE
feat: single-container Docker distribution + CI/CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ dist/
 build/
 .git/
 .planning/
+.claude/
 .env*
 !.env.example
 *.md
@@ -16,3 +17,6 @@ __tests__/
 npm-debug.log*
 data/
 media/
+docker/Dockerfile
+docker/Dockerfile.backend
+docker/docker-compose.yml

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,42 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ninjaguydev/autoblow-panel:${{ steps.version.outputs.version }}
+            ninjaguydev/autoblow-panel:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+# Stage 1: Build frontend (Vite SPA)
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json tsconfig.app.json tsconfig.node.json vite.config.ts index.html ./
+COPY src/ ./src/
+COPY public/ ./public/
+COPY server/types/ ./server/types/
+
+RUN npx vite build
+
+
+# Stage 2: Compile backend TypeScript
+FROM node:20-alpine AS backend-builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.server.json ./
+COPY server/ ./server/
+
+RUN npx tsc --project tsconfig.server.json --outDir dist/server --noEmit false
+
+
+# Stage 3: Production dependencies (with native better-sqlite3)
+FROM node:20-alpine AS deps
+
+WORKDIR /app
+
+RUN apk add --no-cache python3 make g++
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+
+# Stage 4: Runtime
+FROM node:20-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache nginx
+
+# Production node_modules (with native better-sqlite3)
+COPY --from=deps /app/node_modules ./node_modules/
+
+# Compiled backend JS
+COPY --from=backend-builder /app/dist/server ./server/
+
+# Built SPA
+COPY --from=frontend-builder /app/dist /usr/share/nginx/html/
+
+# Nginx config for single-container mode
+COPY docker/nginx.production.conf /etc/nginx/nginx.conf
+
+# Entrypoint script
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# package.json needed for ESM module resolution
+COPY package.json ./
+
+# Create runtime directories for volumes
+RUN mkdir -p /app/data /app/media
+
+ENV NODE_ENV=production
+ENV DB_PATH=/app/data/autoblow.db
+ENV MEDIA_DIR=/app/media
+ENV PORT=3001
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD wget --spider -q http://localhost/health || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+
+NODE_PID=""
+NGINX_PID=""
+
+cleanup() {
+  echo "Shutting down..."
+  [ -n "$NODE_PID" ] && kill "$NODE_PID" 2>/dev/null
+  [ -n "$NGINX_PID" ] && kill "$NGINX_PID" 2>/dev/null
+  wait
+  exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+# Start Node.js backend
+node /app/server/index.js &
+NODE_PID=$!
+
+# Wait for backend to be ready (up to 30s)
+echo "Waiting for backend..."
+ATTEMPTS=0
+MAX_ATTEMPTS=30
+while [ $ATTEMPTS -lt $MAX_ATTEMPTS ]; do
+  if wget --spider -q http://127.0.0.1:3001/health 2>/dev/null; then
+    echo "Backend is ready"
+    break
+  fi
+  ATTEMPTS=$((ATTEMPTS + 1))
+  sleep 1
+done
+
+if [ $ATTEMPTS -eq $MAX_ATTEMPTS ]; then
+  echo "Backend failed to start within ${MAX_ATTEMPTS}s"
+  kill "$NODE_PID" 2>/dev/null
+  exit 1
+fi
+
+# Start nginx
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+
+echo "All services started"
+
+# Monitor both processes — if either exits, shut down
+while kill -0 "$NODE_PID" 2>/dev/null && kill -0 "$NGINX_PID" 2>/dev/null; do
+  wait -n "$NODE_PID" "$NGINX_PID" 2>/dev/null && break || break
+done
+
+echo "A process exited, shutting down"
+cleanup

--- a/docker/nginx.production.conf
+++ b/docker/nginx.production.conf
@@ -1,0 +1,67 @@
+worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  # Performance optimizations
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+
+  # Large upload support (multer allows 10GB)
+  client_max_body_size 11g;
+
+  # Gzip compression
+  gzip on;
+  gzip_vary on;
+  gzip_comp_level 6;
+  gzip_types text/plain text/css text/xml text/javascript application/json application/javascript application/xml+rss;
+
+  # Security headers (global)
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+  # CSP matching helmet config - allows iframe embeds for YouTube, Vimeo, adult platforms
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://*.pornhub.com https://*.xvideos.com; img-src 'self' data: https:; connect-src 'self';" always;
+
+  server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Static asset caching
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+      expires 1y;
+      add_header Cache-Control "public, immutable";
+    }
+
+    # API proxy to backend (same container)
+    location /api {
+      proxy_pass http://127.0.0.1:3001;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_read_timeout 3600s;
+      proxy_request_buffering off;
+    }
+
+    # Health check proxy
+    location /health {
+      proxy_pass http://127.0.0.1:3001;
+    }
+
+    # SPA fallback - must be last
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -53,11 +53,13 @@ if (process.env.NODE_ENV === 'production') {
   app.use(createSecurityMiddleware());
 }
 
-// Configure CORS for Vite dev server
-app.use(cors({
-  origin: 'http://localhost:5173',
-  credentials: true,
-}));
+// Configure CORS for Vite dev server (not needed in production — nginx serves same-origin)
+if (process.env.NODE_ENV !== 'production') {
+  app.use(cors({
+    origin: 'http://localhost:5173',
+    credentials: true,
+  }));
+}
 
 // Configure JSON body parser with large limit for funscript data
 app.use(express.json({ limit: '50mb' }));

--- a/server/middleware/validation.ts
+++ b/server/middleware/validation.ts
@@ -5,7 +5,8 @@ import type { Request, Response } from 'express';
  * Returns the parsed number, or null if the response was already sent.
  */
 export function parseIdParam(req: Request, res: Response, paramName: string = 'id'): number | null {
-  const value = parseInt(req.params[paramName], 10);
+  const raw = req.params[paramName];
+  const value = parseInt(Array.isArray(raw) ? raw[0] : raw, 10);
   if (isNaN(value)) {
     res.status(400).json({ error: `Invalid ${paramName} parameter — must be a number` });
     return null;


### PR DESCRIPTION
## Summary

- Unified 4-stage multi-stage Dockerfile for one-command deployment (`docker run`) without cloning the repo
- GitHub Actions workflow auto-publishes multi-arch images (`linux/amd64`, `linux/arm64`) to Docker Hub on `v*` tags
- Single-container nginx + Node.js with process manager entrypoint, health polling, and signal forwarding

## Changes

**New files:**
- `Dockerfile` — 4-stage build: frontend-builder, backend-builder, deps, runtime (node:20-alpine + nginx)
- `docker/nginx.production.conf` — Same-container proxy (`127.0.0.1:3001`), `client_max_body_size 11g`, `proxy_read_timeout 3600s`
- `docker/entrypoint.sh` — Starts Node + nginx, polls `/health` up to 30s, monitors both processes
- `.github/workflows/docker-publish.yml` — Triggered on `v*` tags, builds + pushes `ninjaguydev/autoblow-panel:{version}` + `:latest`

**Modified files:**
- `server/index.ts` — CORS conditional on `NODE_ENV !== 'production'` (nginx serves same-origin in prod)
- `server/middleware/validation.ts` — Fix pre-existing Express 5 TS error (`string | string[]` param type)
- `.dockerignore` — Added `.claude/`, `docker/Dockerfile`, `docker/Dockerfile.backend`, `docker/docker-compose.yml`

## Usage

```bash
docker run -d -p 8080:80 -v ab-data:/app/data -v ab-media:/app/media ninjaguydev/autoblow-panel
```

## Setup required

Add GitHub repo secrets: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`

## Test plan

- [x] `docker build -t autoblow-panel .` builds without errors
- [x] `docker run -d -p 8080:80 -v ab-data:/app/data -v ab-media:/app/media --name ab autoblow-panel`
- [x] `curl http://localhost:8080/health` → `{"status":"ok"}`
- [x] `http://localhost:8080` → app loads (HTTP 200)
- [x] `curl http://localhost:8080/api/library` → `[]`
- [ ] Test video upload through UI
- [ ] `git tag v1.x.x && git push origin v1.x.x` → GitHub Actions builds and pushes to Docker Hub