### PR TITLE
docs: restructure README with disclaimer and Docker install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,109 +1,114 @@
 # Autoblow Panel
 
-A React-based control interface for the Autoblow AI Ultra device. Create, edit, and synchronize motion scripts with video playback.
+> **Disclaimer:** This project is not affiliated with, endorsed by, or associated with Autoblow or its parent company in any way. This is an independent, community-built tool. Use at your own risk. The authors are not responsible for any damage to devices, data loss, or other issues arising from the use of this software.
+
+A local-first web application for controlling the Autoblow AI Ultra device. Create and edit funscript motion scripts, synchronize playback with local or embedded video, manage a content library, and build playlists — all running on your machine with no uploads, tracking, or analytics.
+
+## Installation
+
+### Docker (Recommended)
+
+Run a single container from Docker Hub — no cloning required:
+
+```bash
+docker run -d \
+  -p 8080:80 \
+  -v ab-data:/app/data \
+  -v ab-media:/app/media \
+  --name autoblow-panel \
+  ninjaguydev/autoblow-panel
+```
+
+Open `http://localhost:8080` in your browser.
+
+The two volumes persist your library database and uploaded media across container restarts.
+
+### npm (Development)
+
+Requires [Node.js](https://nodejs.org/) v18+ and npm.
+
+```bash
+git clone git@github.com:NinjaGuyDev/autoblow-panel.git
+cd autoblow-panel
+npm install
+npm run dev
+```
+
+Frontend runs on `http://localhost:5173`, backend API on port 3001.
 
 ## Features
 
 ### Video Synchronization
-- Load video files and funscript motion scripts side by side
 - Real-time video-to-device sync with automatic drift correction
 - Latency estimation and offset adjustment
-- Supports MP4, WebM, and OGG video formats
+- Local video files (MP4, WebM, OGG, MKV, AVI) and embedded video (YouTube, Vimeo)
+- Fullscreen video with keyboard shortcut
 
-### Script Creation
-- Create new motion scripts from scratch using the pattern library
-- Name your scripts and export as `.funscript` files
-- Supports both original and metadata funscript formats
+### Script Library
+- Standalone script playback page with randomized script selection
+- Save scripts to your persistent library
+- Device pause button toggles video play/pause
 
-### Pattern Library
-- Browse 37+ pre-built motion patterns (waves, pulses, rhythmic, escalating, and more)
-- Filter by intensity (low, medium, high) and style tags
-- Animated canvas previews on hover
-- Quick-add button for fast pattern insertion in creation mode
-- Demo playback on connected device from pattern detail view
-- Smart insertion with smooth transitions between patterns
+### Content Library & Playlists
+- SQLite-backed persistent library for videos, funscripts, and custom patterns
+- Drag-and-drop playlist management with reordering
+- Video upload with streaming playback and thumbnail generation
+- Search and browse your collection
 
 ### Timeline Editor
-- Canvas-based editor for precise motion control at 60 FPS
-- Select, draw, and drag action points
-- Freehand drawing mode for custom motion curves
+- Canvas-based editor at 60 FPS with select, draw, and drag modes
+- Freehand drawing for custom motion curves
 - Rectangle selection for multi-point editing
 - Undo/redo with 50-level history
-- Validation overlay highlighting safe, fast, and impossible motion segments
-- Playhead tracking synchronized with video
+- Validation overlay (safe, fast, impossible segments)
+- Pattern insertion with smooth transitions
+
+### Pattern Library
+- 37+ pre-built motion patterns (waves, pulses, rhythmic, escalating, and more)
+- Filter by intensity and style tags
+- Animated canvas previews on hover
+- Demo playback on connected device
+- Custom pattern creation with waypoint builder
 
 ### Manual Device Control
 - Direct oscillation control with speed, min/max range sliders
-- Sine wave, triangle wave, and random walk pattern generators
-- Mutual exclusion with sync playback (prevents conflicting commands)
+- Sine wave, triangle wave, and random walk generators
 
-### Session Persistence
-- Auto-saves work sessions to IndexedDB
-- Recovers video and script state on page reload
-- Device token persisted across sessions
+### Script Creation & Export
+- Create scripts from scratch using the pattern library
+- Export as `.funscript` files (original and metadata formats)
 
-## Installation
+## Roadmap
 
-### Prerequisites
-
-- [Node.js](https://nodejs.org/) (v18 or later)
-- npm (included with Node.js)
-- An Autoblow AI Ultra device and token (for device features)
-
-### Setup
-
-```bash
-# Clone the repository
-git clone git@github.com:NinjaGuyDev/autoblow-panel.git
-cd autoblow-panel
-
-# Install dependencies
-npm install
-
-# Start the development server
-npm run dev
-```
-
-The app will be available at `http://localhost:3000`.
-
-### Build for Production
-
-```bash
-# Type-check and build
-npm run build
-
-# Preview the production build
-npm run preview
-```
-
-The build output is in the `dist/` directory and can be served by any static file host.
-
-### Linting
-
-```bash
-npm run lint
-```
+| Version | Status | Highlights |
+|---------|--------|------------|
+| v1.0 | Shipped | Core playback, timeline editor, pattern library, manual control |
+| v1.1 | Shipped | Express + SQLite backend, content library, playlists, embedded video, Docker deployment |
+| v1.2 | Shipped | Script Library page, device pause, fullscreen, UI redesign |
+| v1.3 | In Progress | Session analytics, climax tracking, script chapters, usage dashboard |
+| v1.4 | Planned | Intensity profiles, remote control, script blending, theater mode |
 
 ## Tech Stack
 
 | Layer | Technology |
 |-------|-----------|
-| Framework | React 19 |
-| Language | TypeScript 5.9 |
-| Build Tool | Vite 7 |
-| Styling | Tailwind CSS 4 |
+| Frontend | React 19, TypeScript 5.9, Vite 7, Tailwind CSS 4 |
+| Backend | Express 5, SQLite (better-sqlite3) |
 | Device SDK | @xsense/autoblow-sdk |
-| Validation | Zod |
-| Local Storage | Dexie (IndexedDB) |
+| Deployment | Docker (nginx + Node.js single container) |
 
 ## Usage
 
 1. **Connect your device** -- Enter your device token in the header connection button
-2. **Load media** -- Drag and drop a video file and/or `.funscript` file onto the app
+2. **Load media** -- Drag and drop a video file and/or `.funscript` file, or upload through the library
 3. **Edit** -- Use the timeline editor to modify action points, or browse the pattern library to build a script
-4. **Create** -- Click "New Script" to start from scratch, name it, and add patterns from the library
+4. **Create** -- Click "New Script" to start from scratch, add patterns from the library
 5. **Sync** -- Press play to synchronize video playback with your device
-6. **Export** -- Save your work as a `.funscript` file
+6. **Export** -- Save your work as a `.funscript` file or to your library
+
+## Contributing
+
+Issues and pull requests are welcome on [GitHub](https://github.com/NinjaGuyDev/autoblow-panel).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Added legal disclaimer (not affiliated with Autoblow, use at own risk)
- Reordered sections: disclaimer, description, installation (Docker + npm), features, roadmap, tech stack, usage
- Updated features to reflect v1.2 additions (script library, embedded video, playlists)
- Added roadmap table (v1.0–v1.4)
- Updated tech stack to include backend (Express, SQLite)
- Added contributing section

## Test plan

- [x] README renders correctly on GitHub