### PR TITLE
fix: adjust pre-packaged pattern definitions

### DIFF
--- a/src/types/patterns.ts
+++ b/src/types/patterns.ts
@@ -47,7 +47,8 @@ export type StyleTag =
   | 'zigzag'
   | 'plateau'
   | 'gradual'
-  | 'incremental';
+  | 'incremental'
+  | 'pause';
 
 /**
  * A pattern definition with metadata and action generator


### PR DESCRIPTION
## Summary
- Fix Wave Down Slow: convert to `patternPair()` as proper mirror of Wave Up Slow (was completely broken with wrong actions/duration)
- Cap all pre-packaged patterns at 8 seconds with proportional action scaling via `capActions()` helper
- Add three new pause patterns: High Pause (pos 100), Mid Pause (pos 50), Low Pause (pos 0) — 2 seconds each
- Increase Rapid Pulse duration from 5s to 12s to reduce device stress
- Add `'pause'` to `StyleTag` union type

## Test plan
- [ ] Verify Wave Down Slow mirrors Wave Up Slow in the pattern library preview
- [ ] Confirm no pre-packaged pattern exceeds 8 seconds duration
- [ ] Check the three new pause patterns appear and display correctly
- [ ] Verify Rapid Pulse plays at a comfortable pace