### PR TITLE
feat: add edit, rename, and soft-delete for custom patterns

### DIFF
--- a/server/controllers/library.controller.ts
+++ b/server/controllers/library.controller.ts
@@ -57,6 +57,17 @@ export class LibraryController {
     }
   };
 
+  softDeleteCustomPattern = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const id = parseIdParam(req, res);
+      if (id === null) return;
+      this.service.softDeleteCustomPattern(id);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  };
+
   create = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const data = req.body as CreateLibraryItemRequest;

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -59,6 +59,13 @@ export function initializeSchema(db: Database.Database): void {
     `);
   }
 
+  if (!existingColumns.has('deletedAt')) {
+    db.exec(`
+      ALTER TABLE library_items
+      ADD COLUMN deletedAt TEXT;
+    `);
+  }
+
   // Create index on isCustomPattern for efficient filtering
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_library_custom_pattern ON library_items(isCustomPattern);

--- a/server/repositories/library.repository.ts
+++ b/server/repositories/library.repository.ts
@@ -7,7 +7,8 @@ export class LibraryRepository {
   findAll(): LibraryItem[] {
     const stmt = this.db.prepare(`
       SELECT * FROM library_items
-      WHERE isCustomPattern = 0 OR isCustomPattern IS NULL
+      WHERE (isCustomPattern = 0 OR isCustomPattern IS NULL)
+        AND deletedAt IS NULL
       ORDER BY lastModified DESC
     `);
     return stmt.all() as LibraryItem[];
@@ -26,6 +27,7 @@ export class LibraryRepository {
       SELECT * FROM library_items
       WHERE (videoName LIKE ? OR funscriptName LIKE ?)
         AND (isCustomPattern = 0 OR isCustomPattern IS NULL)
+        AND deletedAt IS NULL
       ORDER BY lastModified DESC
     `);
     return stmt.all(searchPattern, searchPattern) as LibraryItem[];
@@ -35,6 +37,7 @@ export class LibraryRepository {
     const stmt = this.db.prepare(`
       SELECT * FROM library_items
       WHERE isCustomPattern = 1
+        AND deletedAt IS NULL
       ORDER BY lastModified DESC
     `);
     return stmt.all() as LibraryItem[];
@@ -62,6 +65,16 @@ export class LibraryRepository {
   delete(id: number): number {
     const stmt = this.db.prepare(`
       DELETE FROM library_items WHERE id = ?
+    `);
+    const result = stmt.run(id);
+    return result.changes;
+  }
+
+  softDelete(id: number): number {
+    const stmt = this.db.prepare(`
+      UPDATE library_items
+      SET deletedAt = datetime('now')
+      WHERE id = ? AND deletedAt IS NULL
     `);
     const result = stmt.run(id);
     return result.changes;

--- a/server/routes/library.routes.ts
+++ b/server/routes/library.routes.ts
@@ -31,7 +31,10 @@ export function createLibraryRouter(controller: LibraryController): Router {
   // Update custom pattern
   router.patch('/:id', controller.updateCustomPattern);
 
-  // Delete library item
+  // Soft-delete custom pattern (preserves record for stats references)
+  router.delete('/custom-patterns/:id', controller.softDeleteCustomPattern);
+
+  // Hard-delete library item
   router.delete('/:id', controller.delete);
 
   return router;

--- a/server/services/library.service.ts
+++ b/server/services/library.service.ts
@@ -49,6 +49,20 @@ export class LibraryService {
     return this.repository.updateCustomPattern(id, data);
   }
 
+  softDeleteCustomPattern(id: number): void {
+    const item = this.repository.findById(id);
+    if (!item) {
+      throw new Error(`Library item with id ${id} not found`);
+    }
+    if (item.isCustomPattern !== 1) {
+      throw new Error(`Library item with id ${id} is not a custom pattern`);
+    }
+    const changes = this.repository.softDelete(id);
+    if (changes === 0) {
+      throw new Error(`Library item with id ${id} is already deleted`);
+    }
+  }
+
   createItem(data: CreateLibraryItemRequest): LibraryItem {
     // Validate required fields
     if (!data.funscriptData) {

--- a/server/types/shared.ts
+++ b/server/types/shared.ts
@@ -12,6 +12,7 @@ export interface LibraryItem {
   isCustomPattern?: number; // 0=regular library item, 1=custom pattern
   originalPatternId?: string | null; // Preset pattern ID this was copied from
   patternMetadata?: string | null; // JSON string with pattern metadata
+  deletedAt?: string | null; // ISO 8601 timestamp for soft delete
 }
 
 export interface CreateLibraryItemRequest {

--- a/src/components/pattern-library/PatternEditorDialog.tsx
+++ b/src/components/pattern-library/PatternEditorDialog.tsx
@@ -19,6 +19,7 @@ interface PatternEditorDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onActionsChange: (actions: FunscriptAction[]) => void;
+  onNameChange: (name: string) => void;
   onDurationChange: (seconds: number) => void;
   onIntensityChange: (delta: number) => void;
   onStartDemo: () => void;
@@ -43,6 +44,7 @@ export function PatternEditorDialog({
   isOpen,
   onClose,
   onActionsChange,
+  onNameChange,
   onDurationChange,
   onIntensityChange,
   onStartDemo,
@@ -165,7 +167,13 @@ export function PatternEditorDialog({
       onStartDemo={onStartDemo}
       onStopDemo={onStopDemo}
       header={
-        <h2 className="text-xl font-semibold text-stone-200" style={{ fontFamily: 'var(--font-display)' }}>{pattern.name}</h2>
+        <input
+          type="text"
+          value={pattern.name}
+          onChange={(e) => onNameChange(e.target.value)}
+          className="text-xl font-semibold text-stone-200 bg-transparent border-b border-stone-700 focus:border-amber-700 focus:outline-none w-full pb-1"
+          style={{ fontFamily: 'var(--font-display)' }}
+        />
       }
     >
       {/* Canvas */}

--- a/src/hooks/usePatternEditor.ts
+++ b/src/hooks/usePatternEditor.ts
@@ -45,6 +45,16 @@ export function usePatternEditor() {
   }, []);
 
   /**
+   * Updates pattern name
+   */
+  const changeName = useCallback((name: string) => {
+    setEditedPattern((prev) => {
+      if (!prev) return null;
+      return { ...prev, name, lastModified: Date.now() };
+    });
+  }, []);
+
+  /**
    * Updates pattern actions (immutable)
    */
   const updateActions = useCallback((actions: FunscriptAction[]) => {
@@ -224,6 +234,7 @@ export function usePatternEditor() {
     demoError,
     openEditor,
     closeEditor,
+    changeName,
     updateActions,
     changeDuration,
     changeIntensity,

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -95,7 +95,7 @@ export const customPatternApi = {
   },
 
   async delete(id: number): Promise<void> {
-    return libraryApi.deleteItem(id);
+    return fetchVoid(`${API_BASE}/custom-patterns/${id}`, { method: 'DELETE' });
   },
 };
 


### PR DESCRIPTION
## Summary
- **Edit button**: Custom patterns now show an "Edit" button in the detail dialog that opens the editor with the existing pattern (preserving `libraryItemId` for PATCH updates)
- **Rename**: Pattern name in the editor dialog is now an editable input field instead of static text
- **Copy name prompt**: When creating a copy of a pattern, a name prompt dialog appears with the default name pre-filled
- **Soft delete**: Custom patterns can be deleted via a "Delete" button with inline confirmation. Records are preserved in the database with a `deletedAt` timestamp (for stats references) rather than hard-deleted

### Backend changes
- Added `deletedAt TEXT` column to `library_items` via idempotent migration
- Added `softDelete()` repository method and `softDeleteCustomPattern()` service method
- Added `DELETE /api/library/custom-patterns/:id` route for soft-delete
- All list/search/custom-pattern queries now filter `WHERE deletedAt IS NULL`

## Test plan
- [ ] Click a custom pattern → "Edit" button appears, opens editor with current data
- [ ] Change the name in the editor, save → name persists on reload
- [ ] Click "Edit Copy" on any pattern → name prompt appears with "(Copy)" suffix
- [ ] Click "Delete" on a custom pattern → confirmation appears, confirm → pattern disappears from library
- [ ] Verify deleted pattern row still exists in SQLite with `deletedAt` set
- [ ] Verify preset patterns do not show Edit or Delete buttons