### PR TITLE
feat: Zod request validation and prepared statement caching

### DIFF
--- a/server/controllers/analytics.controller.ts
+++ b/server/controllers/analytics.controller.ts
@@ -1,7 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { parseIdParam, parseQueryParamInt, requireStringQueryParam } from '../middleware/validation.js';
 import type { ClimaxService } from '../services/climax.service.js';
-import type { CreateClimaxRecordRequest, CreatePauseEventRequest } from '../types/shared.js';
 
 export class AnalyticsController {
   constructor(private climaxService: ClimaxService) {}
@@ -47,8 +46,7 @@ export class AnalyticsController {
 
   createClimaxRecord = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const data = req.body as CreateClimaxRecordRequest;
-      const record = this.climaxService.createClimaxRecord(data);
+      const record = this.climaxService.createClimaxRecord(req.body);
       res.status(201).json(record);
     } catch (error) {
       next(error);
@@ -81,8 +79,7 @@ export class AnalyticsController {
 
   createPauseEvent = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const data = req.body as CreatePauseEventRequest;
-      const event = this.climaxService.createPauseEvent(data);
+      const event = this.climaxService.createPauseEvent(req.body);
       res.status(201).json(event);
     } catch (error) {
       next(error);

--- a/server/controllers/device.controller.ts
+++ b/server/controllers/device.controller.ts
@@ -1,6 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { DeviceService } from '../services/device.service.js';
-import type { DeviceConnectRequest, DevicePlayRequest } from '../types/shared.js';
 import { parseIdParam } from '../middleware/validation.js';
 
 export class DeviceController {
@@ -8,13 +7,7 @@ export class DeviceController {
 
   connect = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const body = req.body ?? {};
-      const { deviceKey } = body as DeviceConnectRequest;
-      if (!deviceKey || typeof deviceKey !== 'string') {
-        res.status(400).json({ error: 'deviceKey is required and must be a string' });
-        return;
-      }
-
+      const { deviceKey } = req.body;
       const result = await this.service.connect(deviceKey);
       res.json(result);
     } catch (error) {
@@ -45,14 +38,7 @@ export class DeviceController {
 
   play = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const body = req.body ?? {};
-      const { actions } = body as DevicePlayRequest;
-      const validationError = validateActions(actions);
-      if (validationError) {
-        res.status(400).json({ error: validationError });
-        return;
-      }
-
+      const { actions } = req.body;
       const result = await this.service.play(actions);
       res.json(result);
     } catch (error) {
@@ -119,32 +105,4 @@ export class DeviceController {
       next(error);
     }
   };
-}
-
-/**
- * Validate funscript actions array.
- * Returns an error message string, or null if valid.
- */
-function validateActions(actions: unknown): string | null {
-  if (!Array.isArray(actions) || actions.length === 0) {
-    return 'actions must be a non-empty array';
-  }
-
-  for (let i = 0; i < actions.length; i++) {
-    const action = actions[i];
-    if (typeof action !== 'object' || action === null) {
-      return `actions[${i}] must be an object with pos and at`;
-    }
-    if (typeof action.pos !== 'number' || action.pos < 0 || action.pos > 100) {
-      return `actions[${i}].pos must be a number between 0 and 100`;
-    }
-    if (typeof action.at !== 'number' || action.at < 0) {
-      return `actions[${i}].at must be a non-negative number`;
-    }
-    if (i > 0 && action.at < actions[i - 1].at) {
-      return `actions must be sorted by 'at' ascending — actions[${i}].at (${action.at}) < actions[${i - 1}].at (${actions[i - 1].at})`;
-    }
-  }
-
-  return null;
 }

--- a/server/controllers/library.controller.ts
+++ b/server/controllers/library.controller.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { LibraryService } from '../services/library.service.js';
-import type { CreateLibraryItemRequest, SearchQuery, MigrationRequest } from '../types/shared.js';
+import type { SearchQuery } from '../types/shared.js';
 import { parseIdParam } from '../middleware/validation.js';
 
 export class LibraryController {
@@ -49,8 +49,7 @@ export class LibraryController {
     try {
       const id = parseIdParam(req, res);
       if (id === null) return;
-      const data = req.body as Partial<CreateLibraryItemRequest>;
-      const item = this.service.updateItemById(id, data);
+      const item = this.service.updateItemById(id, req.body);
       res.json(item);
     } catch (error) {
       next(error);
@@ -61,8 +60,7 @@ export class LibraryController {
     try {
       const id = parseIdParam(req, res);
       if (id === null) return;
-      const data = req.body as Partial<CreateLibraryItemRequest>;
-      const item = this.service.updateCustomPattern(id, data);
+      const item = this.service.updateCustomPattern(id, req.body);
       res.json(item);
     } catch (error) {
       next(error);
@@ -82,8 +80,7 @@ export class LibraryController {
 
   create = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const data = req.body as CreateLibraryItemRequest;
-      const item = this.service.createItem(data);
+      const item = this.service.createItem(req.body);
       res.status(201).json(item);
     } catch (error) {
       next(error);
@@ -103,8 +100,7 @@ export class LibraryController {
 
   save = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const data = req.body as CreateLibraryItemRequest;
-      const item = this.service.saveOrUpdateItem(data);
+      const item = this.service.saveOrUpdateItem(req.body);
       res.json(item);
     } catch (error) {
       next(error);
@@ -122,7 +118,7 @@ export class LibraryController {
 
   migrate = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const { data } = req.body as MigrationRequest;
+      const { data } = req.body;
       const count = this.service.migrateFromIndexedDB(data);
       res.json({ success: true, count });
     } catch (error) {

--- a/server/controllers/playlist.controller.ts
+++ b/server/controllers/playlist.controller.ts
@@ -1,6 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { PlaylistService } from '../services/playlist.service.js';
-import type { CreatePlaylistRequest, UpdatePlaylistRequest, AddPlaylistItemRequest, ReorderPlaylistItemsRequest } from '../types/shared.js';
 import { parseIdParam } from '../middleware/validation.js';
 
 export class PlaylistController {
@@ -39,8 +38,7 @@ export class PlaylistController {
 
   create = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const data = req.body as CreatePlaylistRequest;
-      const playlist = this.service.createPlaylist(data);
+      const playlist = this.service.createPlaylist(req.body);
       res.status(201).json(playlist);
     } catch (error) {
       next(error);
@@ -51,8 +49,7 @@ export class PlaylistController {
     try {
       const id = parseIdParam(req, res);
       if (id === null) return;
-      const data = req.body as UpdatePlaylistRequest;
-      const playlist = this.service.updatePlaylist(id, data);
+      const playlist = this.service.updatePlaylist(id, req.body);
       res.json(playlist);
     } catch (error) {
       next(error);
@@ -74,7 +71,7 @@ export class PlaylistController {
     try {
       const id = parseIdParam(req, res);
       if (id === null) return;
-      const { libraryItemId } = req.body as AddPlaylistItemRequest;
+      const { libraryItemId } = req.body;
       const item = this.service.addItem(id, libraryItemId);
       res.status(201).json(item);
     } catch (error) {
@@ -97,7 +94,7 @@ export class PlaylistController {
     try {
       const id = parseIdParam(req, res);
       if (id === null) return;
-      const { itemIds } = req.body as ReorderPlaylistItemsRequest;
+      const { itemIds } = req.body;
       this.service.reorderItems(id, itemIds);
       res.status(204).send();
     } catch (error) {

--- a/server/controllers/session.controller.ts
+++ b/server/controllers/session.controller.ts
@@ -1,6 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { SessionService } from '../services/session.service.js';
-import type { CreateSessionRequest, UpdateSessionRequest } from '../types/shared.js';
 import { parseIdParam, parseQueryParamInt, requireStringQueryParam } from '../middleware/validation.js';
 
 export class SessionController {
@@ -28,8 +27,7 @@ export class SessionController {
 
   create = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const data = req.body as CreateSessionRequest;
-      const session = this.service.createSession(data);
+      const session = this.service.createSession(req.body);
       res.status(201).json(session);
     } catch (error) {
       next(error);
@@ -40,8 +38,7 @@ export class SessionController {
     try {
       const id = parseIdParam(req, res);
       if (id === null) return;
-      const data = req.body as UpdateSessionRequest;
-      const session = this.service.updateSession(id, data);
+      const session = this.service.updateSession(id, req.body);
       res.json(session);
     } catch (error) {
       next(error);
@@ -52,7 +49,7 @@ export class SessionController {
     try {
       const id = parseIdParam(req, res);
       if (id === null) return;
-      const { libraryItemId, timestamp } = req.body as { libraryItemId: number; timestamp: string };
+      const { libraryItemId, timestamp } = req.body;
       const session = this.service.appendScriptToSession(id, libraryItemId, timestamp);
       res.json(session);
     } catch (error) {
@@ -64,7 +61,7 @@ export class SessionController {
     try {
       const id = parseIdParam(req, res);
       if (id === null) return;
-      const { endedAt } = req.body as { endedAt?: string };
+      const { endedAt } = req.body;
       const finalEndedAt = endedAt ?? new Date().toISOString();
       const session = this.service.endSession(id, finalEndedAt);
       res.json(session);

--- a/server/middleware/validate-body.ts
+++ b/server/middleware/validate-body.ts
@@ -1,0 +1,19 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { ZodSchema } from 'zod';
+
+export function validateBody(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      const firstIssue = result.error.issues[0];
+      const path = firstIssue.path.join('.');
+      const message = path
+        ? `${path}: ${firstIssue.message}`
+        : firstIssue.message;
+      res.status(400).json({ error: message });
+      return;
+    }
+    req.body = result.data;
+    next();
+  };
+}

--- a/server/repositories/climax.repository.ts
+++ b/server/repositories/climax.repository.ts
@@ -2,65 +2,47 @@ import type Database from 'better-sqlite3';
 import type { ClimaxRecord, CreateClimaxRecordRequest } from '../types/shared.js';
 
 export class ClimaxRepository {
-  constructor(private db: Database.Database) {}
+  private readonly findAllStmt: Database.Statement;
+  private readonly findByIdStmt: Database.Statement;
+  private readonly findBySessionIdStmt: Database.Statement;
+  private readonly findByLibraryItemIdStmt: Database.Statement;
+  private readonly createStmt: Database.Statement;
+  private readonly deleteStmt: Database.Statement;
+  private readonly climaxCountByScriptStmt: Database.Statement;
 
-  findAll(): ClimaxRecord[] {
-    const stmt = this.db.prepare(`
+  constructor(private db: Database.Database) {
+    this.findAllStmt = db.prepare(`
       SELECT * FROM climax_records
       ORDER BY createdAt DESC
     `);
-    return stmt.all() as ClimaxRecord[];
-  }
 
-  findById(id: number): ClimaxRecord | undefined {
-    const stmt = this.db.prepare(`
+    this.findByIdStmt = db.prepare(`
       SELECT * FROM climax_records WHERE id = ?
     `);
-    return stmt.get(id) as ClimaxRecord | undefined;
-  }
 
-  findBySessionId(sessionId: number): ClimaxRecord[] {
-    const stmt = this.db.prepare(`
+    this.findBySessionIdStmt = db.prepare(`
       SELECT * FROM climax_records
       WHERE sessionId = ?
       ORDER BY timestamp ASC
     `);
-    return stmt.all(sessionId) as ClimaxRecord[];
-  }
 
-  findByLibraryItemId(libraryItemId: number): ClimaxRecord[] {
-    const stmt = this.db.prepare(`
+    this.findByLibraryItemIdStmt = db.prepare(`
       SELECT * FROM climax_records
       WHERE libraryItemId = ?
       ORDER BY createdAt DESC
     `);
-    return stmt.all(libraryItemId) as ClimaxRecord[];
-  }
 
-  create(data: CreateClimaxRecordRequest): ClimaxRecord {
-    const stmt = this.db.prepare(`
+    this.createStmt = db.prepare(`
       INSERT INTO climax_records (sessionId, timestamp, runwayData, libraryItemId)
       VALUES (?, ?, ?, ?)
       RETURNING *
     `);
-    return stmt.get(
-      data.sessionId ?? null,
-      data.timestamp,
-      data.runwayData,
-      data.libraryItemId ?? null
-    ) as ClimaxRecord;
-  }
 
-  delete(id: number): number {
-    const stmt = this.db.prepare(`
+    this.deleteStmt = db.prepare(`
       DELETE FROM climax_records WHERE id = ?
     `);
-    const result = stmt.run(id);
-    return result.changes;
-  }
 
-  getClimaxCountByScript(limit: number = 10): Array<{libraryItemId: number, climaxCount: number}> {
-    const stmt = this.db.prepare(`
+    this.climaxCountByScriptStmt = db.prepare(`
       SELECT
         libraryItemId,
         COUNT(*) as climaxCount
@@ -70,6 +52,39 @@ export class ClimaxRepository {
       ORDER BY climaxCount DESC
       LIMIT ?
     `);
-    return stmt.all(limit) as Array<{libraryItemId: number, climaxCount: number}>;
+  }
+
+  findAll(): ClimaxRecord[] {
+    return this.findAllStmt.all() as ClimaxRecord[];
+  }
+
+  findById(id: number): ClimaxRecord | undefined {
+    return this.findByIdStmt.get(id) as ClimaxRecord | undefined;
+  }
+
+  findBySessionId(sessionId: number): ClimaxRecord[] {
+    return this.findBySessionIdStmt.all(sessionId) as ClimaxRecord[];
+  }
+
+  findByLibraryItemId(libraryItemId: number): ClimaxRecord[] {
+    return this.findByLibraryItemIdStmt.all(libraryItemId) as ClimaxRecord[];
+  }
+
+  create(data: CreateClimaxRecordRequest): ClimaxRecord {
+    return this.createStmt.get(
+      data.sessionId ?? null,
+      data.timestamp,
+      data.runwayData,
+      data.libraryItemId ?? null
+    ) as ClimaxRecord;
+  }
+
+  delete(id: number): number {
+    const result = this.deleteStmt.run(id);
+    return result.changes;
+  }
+
+  getClimaxCountByScript(limit: number = 10): Array<{libraryItemId: number, climaxCount: number}> {
+    return this.climaxCountByScriptStmt.all(limit) as Array<{libraryItemId: number, climaxCount: number}>;
   }
 }

--- a/server/repositories/library.repository.ts
+++ b/server/repositories/library.repository.ts
@@ -2,55 +2,134 @@ import type Database from 'better-sqlite3';
 import type { LibraryItem, CreateLibraryItemRequest } from '../types/shared.js';
 
 export class LibraryRepository {
-  constructor(private db: Database.Database) {}
+  private readonly findAllStmt: Database.Statement;
+  private readonly findByIdStmt: Database.Statement;
+  private readonly searchStmt: Database.Statement;
+  private readonly findCustomPatternsStmt: Database.Statement;
+  private readonly createStmt: Database.Statement;
+  private readonly deleteStmt: Database.Statement;
+  private readonly softDeleteStmt: Database.Statement;
+  private readonly updateByIdStmt: Database.Statement;
+  private readonly updateCustomPatternStmt: Database.Statement;
+  private readonly findExistingByNameStmt: Database.Statement;
+  private readonly upsertUpdateStmt: Database.Statement;
+  private readonly getMigrationStatusStmt: Database.Statement;
+  private readonly setMigrationCompleteStmt: Database.Statement;
+  private readonly bulkInsertStmt: Database.Statement;
 
-  findAll(): LibraryItem[] {
-    const stmt = this.db.prepare(`
+  constructor(private db: Database.Database) {
+    this.findAllStmt = db.prepare(`
       SELECT * FROM library_items
       WHERE (isCustomPattern = 0 OR isCustomPattern IS NULL)
         AND deletedAt IS NULL
       ORDER BY lastModified DESC
     `);
-    return stmt.all() as LibraryItem[];
-  }
 
-  findById(id: number): LibraryItem | undefined {
-    const stmt = this.db.prepare(`
+    this.findByIdStmt = db.prepare(`
       SELECT * FROM library_items WHERE id = ?
     `);
-    return stmt.get(id) as LibraryItem | undefined;
-  }
 
-  search(query: string): LibraryItem[] {
-    const searchPattern = `%${query}%`;
-    const stmt = this.db.prepare(`
+    this.searchStmt = db.prepare(`
       SELECT * FROM library_items
       WHERE (videoName LIKE ? OR funscriptName LIKE ?)
         AND (isCustomPattern = 0 OR isCustomPattern IS NULL)
         AND deletedAt IS NULL
       ORDER BY lastModified DESC
     `);
-    return stmt.all(searchPattern, searchPattern) as LibraryItem[];
-  }
 
-  findCustomPatterns(): LibraryItem[] {
-    const stmt = this.db.prepare(`
+    this.findCustomPatternsStmt = db.prepare(`
       SELECT * FROM library_items
       WHERE isCustomPattern = 1
         AND deletedAt IS NULL
       ORDER BY lastModified DESC
     `);
-    return stmt.all() as LibraryItem[];
-  }
 
-  create(item: CreateLibraryItemRequest): LibraryItem {
-    const lastModified = new Date().toISOString();
-    const stmt = this.db.prepare(`
+    this.createStmt = db.prepare(`
       INSERT INTO library_items (videoName, funscriptName, funscriptData, duration, lastModified, isCustomPattern, originalPatternId, patternMetadata)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       RETURNING *
     `);
-    return stmt.get(
+
+    this.deleteStmt = db.prepare(`
+      DELETE FROM library_items WHERE id = ?
+    `);
+
+    this.softDeleteStmt = db.prepare(`
+      UPDATE library_items
+      SET deletedAt = ?
+      WHERE id = ? AND deletedAt IS NULL
+    `);
+
+    this.updateByIdStmt = db.prepare(`
+      UPDATE library_items
+      SET funscriptName = COALESCE(?, funscriptName),
+          funscriptData = COALESCE(?, funscriptData),
+          duration = COALESCE(?, duration),
+          lastModified = ?
+      WHERE id = ?
+      RETURNING *
+    `);
+
+    this.updateCustomPatternStmt = db.prepare(`
+      UPDATE library_items
+      SET funscriptData = COALESCE(?, funscriptData),
+          patternMetadata = COALESCE(?, patternMetadata),
+          lastModified = ?
+      WHERE id = ?
+      RETURNING *
+    `);
+
+    this.findExistingByNameStmt = db.prepare(`
+      SELECT id FROM library_items
+      WHERE (videoName IS ? AND videoName IS NOT NULL)
+         OR (funscriptName IS ? AND funscriptName IS NOT NULL AND videoName IS NULL AND ? IS NULL)
+      ORDER BY lastModified DESC
+      LIMIT 1
+    `);
+
+    this.upsertUpdateStmt = db.prepare(`
+      UPDATE library_items
+      SET funscriptName = ?, funscriptData = ?, duration = ?, lastModified = ?
+      WHERE id = ?
+      RETURNING *
+    `);
+
+    this.getMigrationStatusStmt = db.prepare(`
+      SELECT migrated FROM migration_status WHERE id = 1
+    `);
+
+    this.setMigrationCompleteStmt = db.prepare(`
+      UPDATE migration_status
+      SET migrated = 1, migratedAt = ?
+      WHERE id = 1
+    `);
+
+    this.bulkInsertStmt = db.prepare(`
+      INSERT INTO library_items (videoName, funscriptName, funscriptData, duration, lastModified, isCustomPattern, originalPatternId, patternMetadata)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+  }
+
+  findAll(): LibraryItem[] {
+    return this.findAllStmt.all() as LibraryItem[];
+  }
+
+  findById(id: number): LibraryItem | undefined {
+    return this.findByIdStmt.get(id) as LibraryItem | undefined;
+  }
+
+  search(query: string): LibraryItem[] {
+    const searchPattern = `%${query}%`;
+    return this.searchStmt.all(searchPattern, searchPattern) as LibraryItem[];
+  }
+
+  findCustomPatterns(): LibraryItem[] {
+    return this.findCustomPatternsStmt.all() as LibraryItem[];
+  }
+
+  create(item: CreateLibraryItemRequest): LibraryItem {
+    const lastModified = new Date().toISOString();
+    return this.createStmt.get(
       item.videoName,
       item.funscriptName,
       item.funscriptData,
@@ -63,36 +142,19 @@ export class LibraryRepository {
   }
 
   delete(id: number): number {
-    const stmt = this.db.prepare(`
-      DELETE FROM library_items WHERE id = ?
-    `);
-    const result = stmt.run(id);
+    const result = this.deleteStmt.run(id);
     return result.changes;
   }
 
   softDelete(id: number): number {
     const deletedAt = new Date().toISOString();
-    const stmt = this.db.prepare(`
-      UPDATE library_items
-      SET deletedAt = ?
-      WHERE id = ? AND deletedAt IS NULL
-    `);
-    const result = stmt.run(deletedAt, id);
+    const result = this.softDeleteStmt.run(deletedAt, id);
     return result.changes;
   }
 
   updateById(id: number, item: Partial<CreateLibraryItemRequest>): LibraryItem {
     const lastModified = new Date().toISOString();
-    const stmt = this.db.prepare(`
-      UPDATE library_items
-      SET funscriptName = COALESCE(?, funscriptName),
-          funscriptData = COALESCE(?, funscriptData),
-          duration = COALESCE(?, duration),
-          lastModified = ?
-      WHERE id = ?
-      RETURNING *
-    `);
-    return stmt.get(
+    return this.updateByIdStmt.get(
       item.funscriptName ?? null,
       item.funscriptData ?? null,
       item.duration ?? null,
@@ -103,15 +165,7 @@ export class LibraryRepository {
 
   updateCustomPattern(id: number, item: Partial<CreateLibraryItemRequest>): LibraryItem {
     const lastModified = new Date().toISOString();
-    const stmt = this.db.prepare(`
-      UPDATE library_items
-      SET funscriptData = COALESCE(?, funscriptData),
-          patternMetadata = COALESCE(?, patternMetadata),
-          lastModified = ?
-      WHERE id = ?
-      RETURNING *
-    `);
-    return stmt.get(
+    return this.updateCustomPatternStmt.get(
       item.funscriptData ?? null,
       item.patternMetadata ?? null,
       lastModified,
@@ -122,26 +176,14 @@ export class LibraryRepository {
   upsertByVideoName(item: CreateLibraryItemRequest): LibraryItem {
     const lastModified = new Date().toISOString();
 
-    // Check if item with matching videoName or funscriptName exists
-    // Use IS instead of = for proper NULL comparison in SQL
-    const existingStmt = this.db.prepare(`
-      SELECT id FROM library_items
-      WHERE (videoName IS ? AND videoName IS NOT NULL)
-         OR (funscriptName IS ? AND funscriptName IS NOT NULL AND videoName IS NULL AND ? IS NULL)
-      ORDER BY lastModified DESC
-      LIMIT 1
-    `);
-    const existing = existingStmt.get(item.videoName, item.funscriptName, item.videoName) as { id: number } | undefined;
+    const existing = this.findExistingByNameStmt.get(
+      item.videoName,
+      item.funscriptName,
+      item.videoName
+    ) as { id: number } | undefined;
 
     if (existing) {
-      // Update existing item
-      const updateStmt = this.db.prepare(`
-        UPDATE library_items
-        SET funscriptName = ?, funscriptData = ?, duration = ?, lastModified = ?
-        WHERE id = ?
-        RETURNING *
-      `);
-      return updateStmt.get(
+      return this.upsertUpdateStmt.get(
         item.funscriptName,
         item.funscriptData,
         item.duration,
@@ -149,39 +191,25 @@ export class LibraryRepository {
         existing.id
       ) as LibraryItem;
     } else {
-      // Create new item
       return this.create(item);
     }
   }
 
   getMigrationStatus(): boolean {
-    const stmt = this.db.prepare(`
-      SELECT migrated FROM migration_status WHERE id = 1
-    `);
-    const result = stmt.get() as { migrated: number } | undefined;
+    const result = this.getMigrationStatusStmt.get() as { migrated: number } | undefined;
     return result?.migrated === 1;
   }
 
   setMigrationComplete(): void {
     const migratedAt = new Date().toISOString();
-    const stmt = this.db.prepare(`
-      UPDATE migration_status
-      SET migrated = 1, migratedAt = ?
-      WHERE id = 1
-    `);
-    stmt.run(migratedAt);
+    this.setMigrationCompleteStmt.run(migratedAt);
   }
 
   bulkCreate(items: CreateLibraryItemRequest[]): void {
-    const insertStmt = this.db.prepare(`
-      INSERT INTO library_items (videoName, funscriptName, funscriptData, duration, lastModified, isCustomPattern, originalPatternId, patternMetadata)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
     const insertMany = this.db.transaction((items: CreateLibraryItemRequest[]) => {
       const lastModified = new Date().toISOString();
       for (const item of items) {
-        insertStmt.run(
+        this.bulkInsertStmt.run(
           item.videoName,
           item.funscriptName,
           item.funscriptData,

--- a/server/repositories/pause-event.repository.ts
+++ b/server/repositories/pause-event.repository.ts
@@ -2,45 +2,72 @@ import type Database from 'better-sqlite3';
 import type { PauseEvent, CreatePauseEventRequest, UpdatePauseEventRequest } from '../types/shared.js';
 
 export class PauseEventRepository {
-  constructor(private db: Database.Database) {}
+  private readonly findBySessionIdStmt: Database.Statement;
+  private readonly findByIdStmt: Database.Statement;
+  private readonly createStmt: Database.Statement;
+  private readonly updateStmt: Database.Statement;
+  private readonly deleteStmt: Database.Statement;
+  private readonly avgPauseDurationStmt: Database.Statement;
+  private readonly totalPausesBySessionStmt: Database.Statement;
 
-  findBySessionId(sessionId: number): PauseEvent[] {
-    const stmt = this.db.prepare(`
+  constructor(private db: Database.Database) {
+    this.findBySessionIdStmt = db.prepare(`
       SELECT * FROM pause_events
       WHERE sessionId = ?
       ORDER BY timestamp ASC
     `);
-    return stmt.all(sessionId) as PauseEvent[];
-  }
 
-  findById(id: number): PauseEvent | undefined {
-    const stmt = this.db.prepare(`
+    this.findByIdStmt = db.prepare(`
       SELECT * FROM pause_events WHERE id = ?
     `);
-    return stmt.get(id) as PauseEvent | undefined;
-  }
 
-  create(data: CreatePauseEventRequest): PauseEvent {
-    const stmt = this.db.prepare(`
+    this.createStmt = db.prepare(`
       INSERT INTO pause_events (sessionId, timestamp)
       VALUES (?, ?)
       RETURNING *
     `);
-    return stmt.get(
-      data.sessionId,
-      data.timestamp
-    ) as PauseEvent;
-  }
 
-  update(id: number, data: UpdatePauseEventRequest): PauseEvent {
-    const stmt = this.db.prepare(`
+    this.updateStmt = db.prepare(`
       UPDATE pause_events
       SET resumedAt = COALESCE(?, resumedAt),
           durationSeconds = COALESCE(?, durationSeconds)
       WHERE id = ?
       RETURNING *
     `);
-    return stmt.get(
+
+    this.deleteStmt = db.prepare(`
+      DELETE FROM pause_events WHERE id = ?
+    `);
+
+    this.avgPauseDurationStmt = db.prepare(`
+      SELECT COALESCE(AVG(durationSeconds), 0) as avgDuration
+      FROM pause_events
+      WHERE sessionId = ? AND durationSeconds IS NOT NULL
+    `);
+
+    this.totalPausesBySessionStmt = db.prepare(`
+      SELECT COUNT(*) as count FROM pause_events
+      WHERE sessionId = ?
+    `);
+  }
+
+  findBySessionId(sessionId: number): PauseEvent[] {
+    return this.findBySessionIdStmt.all(sessionId) as PauseEvent[];
+  }
+
+  findById(id: number): PauseEvent | undefined {
+    return this.findByIdStmt.get(id) as PauseEvent | undefined;
+  }
+
+  create(data: CreatePauseEventRequest): PauseEvent {
+    return this.createStmt.get(
+      data.sessionId,
+      data.timestamp
+    ) as PauseEvent;
+  }
+
+  update(id: number, data: UpdatePauseEventRequest): PauseEvent {
+    return this.updateStmt.get(
       data.resumedAt ?? null,
       data.durationSeconds ?? null,
       id
@@ -48,29 +75,17 @@ export class PauseEventRepository {
   }
 
   delete(id: number): number {
-    const stmt = this.db.prepare(`
-      DELETE FROM pause_events WHERE id = ?
-    `);
-    const result = stmt.run(id);
+    const result = this.deleteStmt.run(id);
     return result.changes;
   }
 
   getAvgPauseDuration(sessionId: number): number {
-    const stmt = this.db.prepare(`
-      SELECT COALESCE(AVG(durationSeconds), 0) as avgDuration
-      FROM pause_events
-      WHERE sessionId = ? AND durationSeconds IS NOT NULL
-    `);
-    const result = stmt.get(sessionId) as { avgDuration: number };
+    const result = this.avgPauseDurationStmt.get(sessionId) as { avgDuration: number };
     return result.avgDuration;
   }
 
   getTotalPausesBySession(sessionId: number): number {
-    const stmt = this.db.prepare(`
-      SELECT COUNT(*) as count FROM pause_events
-      WHERE sessionId = ?
-    `);
-    const result = stmt.get(sessionId) as { count: number };
+    const result = this.totalPausesBySessionStmt.get(sessionId) as { count: number };
     return result.count;
   }
 }

--- a/server/repositories/playlist.repository.ts
+++ b/server/repositories/playlist.repository.ts
@@ -2,10 +2,25 @@ import type Database from 'better-sqlite3';
 import type { Playlist, PlaylistItem, CreatePlaylistRequest, UpdatePlaylistRequest } from '../types/shared.js';
 
 export class PlaylistRepository {
-  constructor(private db: Database.Database) {}
+  private readonly findAllStmt: Database.Statement;
+  private readonly findByIdStmt: Database.Statement;
+  private readonly findItemByIdStmt: Database.Statement;
+  private readonly findItemsByPlaylistIdStmt: Database.Statement;
+  private readonly createStmt: Database.Statement;
+  private readonly updateStmt: Database.Statement;
+  private readonly itemCountStmt: Database.Statement;
+  private readonly deleteStmt: Database.Statement;
+  private readonly nextPositionStmt: Database.Statement;
+  private readonly insertItemStmt: Database.Statement;
+  private readonly selectItemWithJoinStmt: Database.Statement;
+  private readonly selectItemForRemoveStmt: Database.Statement;
+  private readonly deleteItemStmt: Database.Statement;
+  private readonly compactPositionsStmt: Database.Statement;
+  private readonly updateItemPositionStmt: Database.Statement;
+  private readonly updatePlaylistLastModifiedStmt: Database.Statement;
 
-  findAll(): Playlist[] {
-    const stmt = this.db.prepare(`
+  constructor(private db: Database.Database) {
+    this.findAllStmt = db.prepare(`
       SELECT
         p.*,
         COUNT(pi.id) as itemCount
@@ -14,11 +29,8 @@ export class PlaylistRepository {
       GROUP BY p.id
       ORDER BY p.lastModified DESC
     `);
-    return stmt.all() as Playlist[];
-  }
 
-  findById(id: number): Playlist | undefined {
-    const stmt = this.db.prepare(`
+    this.findByIdStmt = db.prepare(`
       SELECT
         p.*,
         COUNT(pi.id) as itemCount
@@ -27,11 +39,8 @@ export class PlaylistRepository {
       WHERE p.id = ?
       GROUP BY p.id
     `);
-    return stmt.get(id) as Playlist | undefined;
-  }
 
-  findItemById(itemId: number): PlaylistItem | undefined {
-    const stmt = this.db.prepare(`
+    this.findItemByIdStmt = db.prepare(`
       SELECT
         pi.id,
         pi.playlist_id as playlistId,
@@ -44,11 +53,8 @@ export class PlaylistRepository {
       INNER JOIN library_items li ON pi.library_item_id = li.id
       WHERE pi.id = ?
     `);
-    return stmt.get(itemId) as PlaylistItem | undefined;
-  }
 
-  findItemsByPlaylistId(playlistId: number): PlaylistItem[] {
-    const stmt = this.db.prepare(`
+    this.findItemsByPlaylistIdStmt = db.prepare(`
       SELECT
         pi.id,
         pi.playlist_id as playlistId,
@@ -62,23 +68,14 @@ export class PlaylistRepository {
       WHERE pi.playlist_id = ?
       ORDER BY pi.position ASC
     `);
-    return stmt.all(playlistId) as PlaylistItem[];
-  }
 
-  create(data: CreatePlaylistRequest): Playlist {
-    const stmt = this.db.prepare(`
+    this.createStmt = db.prepare(`
       INSERT INTO playlists (name, description)
       VALUES (?, ?)
       RETURNING *
     `);
-    const row = stmt.get(data.name, data.description ?? null) as Playlist;
-    // Add itemCount for consistency
-    return { ...row, itemCount: 0 };
-  }
 
-  update(id: number, data: UpdatePlaylistRequest): Playlist | undefined {
-    const lastModified = new Date().toISOString();
-    const updateStmt = this.db.prepare(`
+    this.updateStmt = db.prepare(`
       UPDATE playlists
       SET name = COALESCE(?, name),
           description = COALESCE(?, description),
@@ -86,47 +83,28 @@ export class PlaylistRepository {
       WHERE id = ?
       RETURNING *
     `);
-    const countStmt = this.db.prepare(`
+
+    this.itemCountStmt = db.prepare(`
       SELECT COUNT(*) as itemCount FROM playlist_items WHERE playlist_id = ?
     `);
 
-    const runUpdate = this.db.transaction(() => {
-      const row = updateStmt.get(
-        data.name ?? null,
-        data.description ?? null,
-        lastModified,
-        id
-      ) as Playlist | undefined;
-
-      if (!row) return undefined;
-
-      const { itemCount } = countStmt.get(id) as { itemCount: number };
-      return { ...row, itemCount };
-    });
-
-    return runUpdate();
-  }
-
-  delete(id: number): number {
-    const stmt = this.db.prepare(`
+    this.deleteStmt = db.prepare(`
       DELETE FROM playlists WHERE id = ?
     `);
-    const result = stmt.run(id);
-    return result.changes;
-  }
 
-  addItem(playlistId: number, libraryItemId: number): PlaylistItem {
-    const positionStmt = this.db.prepare(`
+    this.nextPositionStmt = db.prepare(`
       SELECT COALESCE(MAX(position), -1) + 1 as nextPosition
       FROM playlist_items
       WHERE playlist_id = ?
     `);
-    const insertStmt = this.db.prepare(`
+
+    this.insertItemStmt = db.prepare(`
       INSERT INTO playlist_items (playlist_id, library_item_id, position)
       VALUES (?, ?, ?)
       RETURNING *
     `);
-    const selectStmt = this.db.prepare(`
+
+    this.selectItemWithJoinStmt = db.prepare(`
       SELECT
         pi.id,
         pi.playlist_id as playlistId,
@@ -140,42 +118,104 @@ export class PlaylistRepository {
       WHERE pi.id = ?
     `);
 
-    const runAddItem = this.db.transaction(() => {
-      const { nextPosition } = positionStmt.get(playlistId) as { nextPosition: number };
+    this.selectItemForRemoveStmt = db.prepare(`
+      SELECT playlist_id, position FROM playlist_items WHERE id = ?
+    `);
 
-      const insertedRow = insertStmt.get(playlistId, libraryItemId, nextPosition) as {
+    this.deleteItemStmt = db.prepare(`
+      DELETE FROM playlist_items WHERE id = ?
+    `);
+
+    this.compactPositionsStmt = db.prepare(`
+      UPDATE playlist_items
+      SET position = position - 1
+      WHERE playlist_id = ? AND position > ?
+    `);
+
+    this.updateItemPositionStmt = db.prepare(`
+      UPDATE playlist_items
+      SET position = ?
+      WHERE id = ?
+    `);
+
+    this.updatePlaylistLastModifiedStmt = db.prepare(`
+      UPDATE playlists
+      SET lastModified = ?
+      WHERE id = ?
+    `);
+  }
+
+  findAll(): Playlist[] {
+    return this.findAllStmt.all() as Playlist[];
+  }
+
+  findById(id: number): Playlist | undefined {
+    return this.findByIdStmt.get(id) as Playlist | undefined;
+  }
+
+  findItemById(itemId: number): PlaylistItem | undefined {
+    return this.findItemByIdStmt.get(itemId) as PlaylistItem | undefined;
+  }
+
+  findItemsByPlaylistId(playlistId: number): PlaylistItem[] {
+    return this.findItemsByPlaylistIdStmt.all(playlistId) as PlaylistItem[];
+  }
+
+  create(data: CreatePlaylistRequest): Playlist {
+    const row = this.createStmt.get(data.name, data.description ?? null) as Playlist;
+    return { ...row, itemCount: 0 };
+  }
+
+  update(id: number, data: UpdatePlaylistRequest): Playlist | undefined {
+    const lastModified = new Date().toISOString();
+
+    const runUpdate = this.db.transaction(() => {
+      const row = this.updateStmt.get(
+        data.name ?? null,
+        data.description ?? null,
+        lastModified,
+        id
+      ) as Playlist | undefined;
+
+      if (!row) return undefined;
+
+      const { itemCount } = this.itemCountStmt.get(id) as { itemCount: number };
+      return { ...row, itemCount };
+    });
+
+    return runUpdate();
+  }
+
+  delete(id: number): number {
+    const result = this.deleteStmt.run(id);
+    return result.changes;
+  }
+
+  addItem(playlistId: number, libraryItemId: number): PlaylistItem {
+    const runAddItem = this.db.transaction(() => {
+      const { nextPosition } = this.nextPositionStmt.get(playlistId) as { nextPosition: number };
+
+      const insertedRow = this.insertItemStmt.get(playlistId, libraryItemId, nextPosition) as {
         id: number;
         playlist_id: number;
         library_item_id: number;
         position: number;
       };
 
-      return selectStmt.get(insertedRow.id) as PlaylistItem;
+      return this.selectItemWithJoinStmt.get(insertedRow.id) as PlaylistItem;
     });
 
     return runAddItem();
   }
 
   removeItem(itemId: number): boolean {
-    const selectStmt = this.db.prepare(`
-      SELECT playlist_id, position FROM playlist_items WHERE id = ?
-    `);
-    const deleteStmt = this.db.prepare(`
-      DELETE FROM playlist_items WHERE id = ?
-    `);
-    const compactStmt = this.db.prepare(`
-      UPDATE playlist_items
-      SET position = position - 1
-      WHERE playlist_id = ? AND position > ?
-    `);
-
     const runRemove = this.db.transaction(() => {
-      const item = selectStmt.get(itemId) as { playlist_id: number; position: number } | undefined;
+      const item = this.selectItemForRemoveStmt.get(itemId) as { playlist_id: number; position: number } | undefined;
 
       if (!item) return false;
 
-      deleteStmt.run(itemId);
-      compactStmt.run(item.playlist_id, item.position);
+      this.deleteItemStmt.run(itemId);
+      this.compactPositionsStmt.run(item.playlist_id, item.position);
       return true;
     });
 
@@ -183,24 +223,11 @@ export class PlaylistRepository {
   }
 
   reorderItems(playlistId: number, itemIds: number[]): void {
-    const updateStmt = this.db.prepare(`
-      UPDATE playlist_items
-      SET position = ?
-      WHERE id = ?
-    `);
-
-    const updateLastModifiedStmt = this.db.prepare(`
-      UPDATE playlists
-      SET lastModified = ?
-      WHERE id = ?
-    `);
-
-    // Use transaction for atomicity
     const reorder = this.db.transaction((ids: number[]) => {
       ids.forEach((id, index) => {
-        updateStmt.run(index, id);
+        this.updateItemPositionStmt.run(index, id);
       });
-      updateLastModifiedStmt.run(new Date().toISOString(), playlistId);
+      this.updatePlaylistLastModifiedStmt.run(new Date().toISOString(), playlistId);
     });
 
     reorder(itemIds);

--- a/server/repositories/session.repository.ts
+++ b/server/repositories/session.repository.ts
@@ -2,48 +2,39 @@ import type Database from 'better-sqlite3';
 import type { Session, CreateSessionRequest, UpdateSessionRequest, SessionStats, MostPlayedScript } from '../types/shared.js';
 
 export class SessionRepository {
-  constructor(private db: Database.Database) {}
+  private readonly findAllStmt: Database.Statement;
+  private readonly findByIdStmt: Database.Statement;
+  private readonly findByDateRangeStmt: Database.Statement;
+  private readonly createStmt: Database.Statement;
+  private readonly updateStmt: Database.Statement;
+  private readonly deleteStmt: Database.Statement;
+  private readonly getStatsByContextStmt: Database.Statement;
+  private readonly getStatsAllStmt: Database.Statement;
+  private readonly getMostPlayedStmt: Database.Statement;
 
-  findAll(): Session[] {
-    const stmt = this.db.prepare(`
+  constructor(private db: Database.Database) {
+    this.findAllStmt = db.prepare(`
       SELECT * FROM sessions
       ORDER BY startedAt DESC
     `);
-    return stmt.all() as Session[];
-  }
 
-  findById(id: number): Session | undefined {
-    const stmt = this.db.prepare(`
+    this.findByIdStmt = db.prepare(`
       SELECT * FROM sessions WHERE id = ?
     `);
-    return stmt.get(id) as Session | undefined;
-  }
 
-  findByDateRange(startDate: string, endDate: string): Session[] {
-    const stmt = this.db.prepare(`
+    this.findByDateRangeStmt = db.prepare(`
       SELECT * FROM sessions
       WHERE startedAt >= ? AND startedAt < ?
       ORDER BY startedAt DESC
     `);
-    return stmt.all(startDate, endDate) as Session[];
-  }
 
-  create(data: CreateSessionRequest): Session {
-    const stmt = this.db.prepare(`
+    this.createStmt = db.prepare(`
       INSERT INTO sessions (startedAt, libraryItemId, context, scriptOrder)
       VALUES (?, ?, ?, ?)
       RETURNING *
     `);
-    return stmt.get(
-      data.startedAt,
-      data.libraryItemId ?? null,
-      data.context,
-      data.scriptOrder ?? '[]'
-    ) as Session;
-  }
 
-  update(id: number, data: UpdateSessionRequest): Session {
-    const stmt = this.db.prepare(`
+    this.updateStmt = db.prepare(`
       UPDATE sessions
       SET endedAt = COALESCE(?, endedAt),
           durationSeconds = COALESCE(?, durationSeconds),
@@ -51,47 +42,29 @@ export class SessionRepository {
       WHERE id = ?
       RETURNING *
     `);
-    return stmt.get(
-      data.endedAt ?? null,
-      data.durationSeconds ?? null,
-      data.scriptOrder ?? null,
-      id
-    ) as Session;
-  }
 
-  delete(id: number): number {
-    const stmt = this.db.prepare(`
+    this.deleteStmt = db.prepare(`
       DELETE FROM sessions WHERE id = ?
     `);
-    const result = stmt.run(id);
-    return result.changes;
-  }
 
-  getStats(context?: string): SessionStats {
-    if (context) {
-      const stmt = this.db.prepare(`
-        SELECT
-          COUNT(*) as totalSessions,
-          COALESCE(SUM(durationSeconds), 0) as totalDurationSeconds,
-          COALESCE(AVG(durationSeconds), 0) as avgDurationSeconds
-        FROM sessions
-        WHERE context = ?
-      `);
-      return stmt.get(context) as SessionStats;
-    }
+    this.getStatsByContextStmt = db.prepare(`
+      SELECT
+        COUNT(*) as totalSessions,
+        COALESCE(SUM(durationSeconds), 0) as totalDurationSeconds,
+        COALESCE(AVG(durationSeconds), 0) as avgDurationSeconds
+      FROM sessions
+      WHERE context = ?
+    `);
 
-    const stmt = this.db.prepare(`
+    this.getStatsAllStmt = db.prepare(`
       SELECT
         COUNT(*) as totalSessions,
         COALESCE(SUM(durationSeconds), 0) as totalDurationSeconds,
         COALESCE(AVG(durationSeconds), 0) as avgDurationSeconds
       FROM sessions
     `);
-    return stmt.get() as SessionStats;
-  }
 
-  getMostPlayed(limit: number = 10): MostPlayedScript[] {
-    const stmt = this.db.prepare(`
+    this.getMostPlayedStmt = db.prepare(`
       SELECT
         libraryItemId,
         COUNT(*) as playCount,
@@ -103,6 +76,51 @@ export class SessionRepository {
       ORDER BY playCount DESC
       LIMIT ?
     `);
-    return stmt.all(limit) as MostPlayedScript[];
+  }
+
+  findAll(): Session[] {
+    return this.findAllStmt.all() as Session[];
+  }
+
+  findById(id: number): Session | undefined {
+    return this.findByIdStmt.get(id) as Session | undefined;
+  }
+
+  findByDateRange(startDate: string, endDate: string): Session[] {
+    return this.findByDateRangeStmt.all(startDate, endDate) as Session[];
+  }
+
+  create(data: CreateSessionRequest): Session {
+    return this.createStmt.get(
+      data.startedAt,
+      data.libraryItemId ?? null,
+      data.context,
+      data.scriptOrder ?? '[]'
+    ) as Session;
+  }
+
+  update(id: number, data: UpdateSessionRequest): Session {
+    return this.updateStmt.get(
+      data.endedAt ?? null,
+      data.durationSeconds ?? null,
+      data.scriptOrder ?? null,
+      id
+    ) as Session;
+  }
+
+  delete(id: number): number {
+    const result = this.deleteStmt.run(id);
+    return result.changes;
+  }
+
+  getStats(context?: string): SessionStats {
+    if (context) {
+      return this.getStatsByContextStmt.get(context) as SessionStats;
+    }
+    return this.getStatsAllStmt.get() as SessionStats;
+  }
+
+  getMostPlayed(limit: number = 10): MostPlayedScript[] {
+    return this.getMostPlayedStmt.all(limit) as MostPlayedScript[];
   }
 }

--- a/server/routes/analytics.routes.ts
+++ b/server/routes/analytics.routes.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import type { AnalyticsController } from '../controllers/analytics.controller.js';
+import { validateBody } from '../middleware/validate-body.js';
+import { CreateClimaxRecordSchema, CreatePauseEventSchema, ResumePauseEventSchema } from '../schemas/analytics.schemas.js';
 
 export function createAnalyticsRouter(controller: AnalyticsController): Router {
   const router = Router();
@@ -8,14 +10,14 @@ export function createAnalyticsRouter(controller: AnalyticsController): Router {
   router.get('/climax-records', controller.getClimaxRecords);
   router.get('/climax-records/by-script', controller.getClimaxCountByScript);
   router.get('/climax-records/:id', controller.getClimaxRecordById);
-  router.post('/climax-records', controller.createClimaxRecord);
+  router.post('/climax-records', validateBody(CreateClimaxRecordSchema), controller.createClimaxRecord);
   router.delete('/climax-records/:id', controller.deleteClimaxRecord);
 
   // Pause events
   router.get('/pause-events', controller.getPauseEvents);
   router.get('/pause-events/stats', controller.getSessionPauseStats);
-  router.post('/pause-events', controller.createPauseEvent);
-  router.post('/pause-events/:id/resume', controller.resumePauseEvent);
+  router.post('/pause-events', validateBody(CreatePauseEventSchema), controller.createPauseEvent);
+  router.post('/pause-events/:id/resume', validateBody(ResumePauseEventSchema), controller.resumePauseEvent);
   router.delete('/pause-events/:id', controller.deletePauseEvent);
 
   return router;

--- a/server/routes/device.routes.ts
+++ b/server/routes/device.routes.ts
@@ -1,16 +1,18 @@
 import { Router } from 'express';
 import type { DeviceController } from '../controllers/device.controller.js';
+import { validateBody } from '../middleware/validate-body.js';
+import { DeviceConnectSchema, DevicePlaySchema } from '../schemas/device.schemas.js';
 
 export function createDeviceRouter(controller: DeviceController): Router {
   const router = Router();
 
   // Connection lifecycle
-  router.post('/connect', controller.connect);
+  router.post('/connect', validateBody(DeviceConnectSchema), controller.connect);
   router.post('/disconnect', controller.disconnect);
   router.get('/status', controller.status);
 
   // Playback control
-  router.post('/play', controller.play);
+  router.post('/play', validateBody(DevicePlaySchema), controller.play);
   router.post('/play/:id', controller.playById);
   router.post('/pause', controller.pause);
   router.post('/resume', controller.resume);

--- a/server/routes/library.routes.ts
+++ b/server/routes/library.routes.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import type { LibraryController } from '../controllers/library.controller.js';
+import { validateBody } from '../middleware/validate-body.js';
+import { CreateLibraryItemSchema, UpdateLibraryItemSchema, MigrationSchema } from '../schemas/library.schemas.js';
 
 export function createLibraryRouter(controller: LibraryController): Router {
   const router = Router();
@@ -20,19 +22,19 @@ export function createLibraryRouter(controller: LibraryController): Router {
   router.get('/:id', controller.getById);
 
   // Create new library item
-  router.post('/', controller.create);
+  router.post('/', validateBody(CreateLibraryItemSchema), controller.create);
 
   // Migrate from IndexedDB
-  router.post('/migrate', controller.migrate);
+  router.post('/migrate', validateBody(MigrationSchema), controller.migrate);
 
   // Save or update library item
-  router.put('/', controller.save);
+  router.put('/', validateBody(CreateLibraryItemSchema), controller.save);
 
   // Update any library item by id (funscriptData, funscriptName, duration)
-  router.put('/:id', controller.updateById);
+  router.put('/:id', validateBody(UpdateLibraryItemSchema), controller.updateById);
 
   // Update custom pattern
-  router.patch('/:id', controller.updateCustomPattern);
+  router.patch('/:id', validateBody(UpdateLibraryItemSchema), controller.updateCustomPattern);
 
   // Soft-delete custom pattern (preserves record for stats references)
   router.delete('/custom-patterns/:id', controller.softDeleteCustomPattern);

--- a/server/routes/playlist.routes.ts
+++ b/server/routes/playlist.routes.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import type { PlaylistController } from '../controllers/playlist.controller.js';
+import { validateBody } from '../middleware/validate-body.js';
+import { CreatePlaylistSchema, UpdatePlaylistSchema, AddPlaylistItemSchema, ReorderPlaylistItemsSchema } from '../schemas/playlist.schemas.js';
 
 export function createPlaylistRouter(controller: PlaylistController): Router {
   const router = Router();
@@ -14,16 +16,16 @@ export function createPlaylistRouter(controller: PlaylistController): Router {
   router.get('/:id/items', controller.getItems);
 
   // Create new playlist
-  router.post('/', controller.create);
+  router.post('/', validateBody(CreatePlaylistSchema), controller.create);
 
   // Add item to playlist
-  router.post('/:id/items', controller.addItem);
+  router.post('/:id/items', validateBody(AddPlaylistItemSchema), controller.addItem);
 
   // Reorder playlist items (must come before /:id/items/:itemId to avoid "reorder" matching as :itemId)
-  router.put('/:id/items/reorder', controller.reorderItems);
+  router.put('/:id/items/reorder', validateBody(ReorderPlaylistItemsSchema), controller.reorderItems);
 
   // Update playlist
-  router.patch('/:id', controller.update);
+  router.patch('/:id', validateBody(UpdatePlaylistSchema), controller.update);
 
   // Delete playlist
   router.delete('/:id', controller.delete);

--- a/server/routes/session.routes.ts
+++ b/server/routes/session.routes.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import type { SessionController } from '../controllers/session.controller.js';
+import { validateBody } from '../middleware/validate-body.js';
+import { CreateSessionSchema, UpdateSessionSchema, AppendScriptSchema, EndSessionSchema } from '../schemas/session.schemas.js';
 
 export function createSessionRouter(controller: SessionController): Router {
   const router = Router();
@@ -8,10 +10,10 @@ export function createSessionRouter(controller: SessionController): Router {
   router.get('/most-played', controller.getMostPlayed);
   router.get('/', controller.getAll);
   router.get('/:id', controller.getById);
-  router.post('/', controller.create);
-  router.patch('/:id', controller.update);
-  router.post('/:id/scripts', controller.appendScript);
-  router.post('/:id/end', controller.end);
+  router.post('/', validateBody(CreateSessionSchema), controller.create);
+  router.patch('/:id', validateBody(UpdateSessionSchema), controller.update);
+  router.post('/:id/scripts', validateBody(AppendScriptSchema), controller.appendScript);
+  router.post('/:id/end', validateBody(EndSessionSchema), controller.end);
   router.delete('/:id', controller.delete);
 
   return router;

--- a/server/schemas/analytics.schemas.ts
+++ b/server/schemas/analytics.schemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const CreateClimaxRecordSchema = z.object({
+  sessionId: z.number().int().positive().nullable().optional(),
+  timestamp: z.string(),
+  runwayData: z.string(),
+  libraryItemId: z.number().int().positive().nullable().optional(),
+});
+
+export const CreatePauseEventSchema = z.object({
+  sessionId: z.number().int().positive(),
+  timestamp: z.string(),
+});
+
+export const ResumePauseEventSchema = z.object({
+  resumedAt: z.string().min(1).optional(),
+});

--- a/server/schemas/device.schemas.ts
+++ b/server/schemas/device.schemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+const FunscriptActionSchema = z.object({
+  pos: z.number().min(0).max(100),
+  at: z.number().min(0),
+});
+
+export const DeviceConnectSchema = z.object({
+  deviceKey: z.string().min(1),
+});
+
+export const DevicePlaySchema = z.object({
+  actions: z.array(FunscriptActionSchema).min(1),
+}).refine(
+  (data) => data.actions.every((a, i) => i === 0 || a.at >= data.actions[i - 1].at),
+  { message: "actions must be sorted by 'at' ascending", path: ['actions'] },
+);

--- a/server/schemas/library.schemas.ts
+++ b/server/schemas/library.schemas.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const CreateLibraryItemSchema = z.object({
+  videoName: z.string().nullable(),
+  funscriptName: z.string().nullable(),
+  funscriptData: z.string(),
+  duration: z.number().nullable(),
+  isCustomPattern: z.number().optional(),
+  originalPatternId: z.string().nullable().optional(),
+  patternMetadata: z.string().nullable().optional(),
+});
+
+export const UpdateLibraryItemSchema = z.object({
+  funscriptName: z.string().nullable().optional(),
+  funscriptData: z.string().optional(),
+  duration: z.number().nullable().optional(),
+});
+
+export const MigrationSchema = z.object({
+  data: z.array(CreateLibraryItemSchema),
+});

--- a/server/schemas/playlist.schemas.ts
+++ b/server/schemas/playlist.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const CreatePlaylistSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().nullable().optional(),
+});
+
+export const UpdatePlaylistSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().nullable().optional(),
+});
+
+export const AddPlaylistItemSchema = z.object({
+  libraryItemId: z.number().int().positive(),
+});
+
+export const ReorderPlaylistItemsSchema = z.object({
+  itemIds: z.array(z.number().int().positive()).min(1),
+});

--- a/server/schemas/session.schemas.ts
+++ b/server/schemas/session.schemas.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const CreateSessionSchema = z.object({
+  startedAt: z.string(),
+  libraryItemId: z.number().int().positive().nullable().optional(),
+  context: z.string(),
+  scriptOrder: z.string().optional(),
+});
+
+export const UpdateSessionSchema = z.object({
+  endedAt: z.string().nullable().optional(),
+  durationSeconds: z.number().nullable().optional(),
+  scriptOrder: z.string().nullable().optional(),
+});
+
+export const AppendScriptSchema = z.object({
+  libraryItemId: z.number().int().positive(),
+  timestamp: z.string(),
+});
+
+export const EndSessionSchema = z.object({
+  endedAt: z.string().optional(),
+});


### PR DESCRIPTION
## Summary

- Add Zod schemas for all API request bodies: library, playlist, session, analytics, device (#47)
- Create `validateBody(schema)` middleware using `safeParse()` — returns `{ error }` on failure, consistent with existing error responses
- Remove all `req.body as SomeType` casts from controllers
- Remove hand-rolled `validateActions()` from device controller — replaced by `DevicePlaySchema` with `.refine()` for ascending-timestamp sort-order validation
- Cache all prepared statements as `private readonly` constructor properties across 5 repositories (#65)
- `resumedAt` enforces `.min(1)` to prevent empty-string edge case
- `ReorderPlaylistItemsSchema.itemIds` requires `.min(1)`

## Test plan
- [ ] Verify malformed request bodies return 400 with clear error messages
- [ ] Verify valid requests still work unchanged
- [ ] Verify device play rejects unsorted actions
- [ ] Verify empty reorder `itemIds` is rejected
- [ ] Verify repository queries still work with cached statements
- [ ] Run `npx tsc --noEmit` to confirm clean compilation

Closes #47, #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added request validation middleware to analytics, device, library, playlist, and session endpoints. Invalid payloads now return HTTP 400 responses with specific error messages detailing what was incorrect.

* **Performance**
  * Optimized database query execution through statement caching for improved performance across all data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->