### PR TITLE
refactor: consolidate duplicated hooks into shared base hooks

### DIFF
--- a/src/components/layout/CreationFooter.tsx
+++ b/src/components/layout/CreationFooter.tsx
@@ -5,7 +5,7 @@ import { createSmoothTransition } from '@/lib/patternInsertion';
 import { buildFunscript } from '@/lib/funscriptConverter';
 import { getErrorMessage } from '@/lib/getErrorMessage';
 import { libraryApi } from '@/lib/apiClient';
-import { useDemoLoop } from '@/hooks/useDemoLoop';
+import { useScriptLoop } from '@/hooks/useScriptLoop';
 import { cn } from '@/lib/utils';
 
 interface CreationFooterProps {
@@ -39,7 +39,11 @@ export function CreationFooter({
   const [isSaving, setIsSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'error'>('idle');
 
-  useDemoLoop(ultra, isDemoPlaying, scriptDurationMs);
+  const onLoopEnd = useCallback(() => {
+    ultra?.syncScriptStart(0);
+  }, [ultra]);
+
+  useScriptLoop(ultra, isDemoPlaying, scriptDurationMs, onLoopEnd);
 
   // Draw mini timeline
   useEffect(() => {

--- a/src/components/pattern-library/PatternDetailDialog.tsx
+++ b/src/components/pattern-library/PatternDetailDialog.tsx
@@ -6,7 +6,7 @@ import { createSmoothTransition } from '@/lib/patternInsertion';
 import { buildFunscript } from '@/lib/funscriptConverter';
 import { cn } from '@/lib/utils';
 import { getErrorMessage } from '@/lib/getErrorMessage';
-import { useDemoLoop } from '@/hooks/useDemoLoop';
+import { useScriptLoop } from '@/hooks/useScriptLoop';
 import { mediaApi } from '@/lib/apiClient';
 
 interface PatternDetailDialogProps {
@@ -45,7 +45,11 @@ export function PatternDetailDialog({
   const [scriptDurationMs, setScriptDurationMs] = useState(0);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  useDemoLoop(ultra, isDemoPlaying, scriptDurationMs);
+  const onLoopEnd = useCallback(() => {
+    ultra?.syncScriptStart(0);
+  }, [ultra]);
+
+  useScriptLoop(ultra, isDemoPlaying, scriptDurationMs, onLoopEnd);
 
   // Draw pattern with animated playhead
   const drawAnimated = (currentTime: number) => {

--- a/src/hooks/useSearchableLibrary.ts
+++ b/src/hooks/useSearchableLibrary.ts
@@ -1,0 +1,89 @@
+/**
+ * Base hook for searchable library data with debounced search, delete, and refresh.
+ * Parameterized by a filter predicate to support different library views
+ * (video library, script-only library, etc.).
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+import { libraryApi } from '@/lib/apiClient';
+import { useAsyncOperation } from '@/hooks/useAsyncOperation';
+import type { LibraryItem } from '@server/types/shared';
+
+interface UseSearchableLibraryOptions {
+  /** Predicate applied to every fetched item; only matching items are returned. */
+  filter: (item: LibraryItem) => boolean;
+  /** Error message shown when fetching fails. */
+  fetchErrorMessage?: string;
+  /** Error message shown when deleting fails. */
+  deleteErrorMessage?: string;
+}
+
+interface UseSearchableLibraryReturn {
+  items: LibraryItem[];
+  loading: boolean;
+  error: string | null;
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  deleteItem: (id: number) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useSearchableLibrary({
+  filter,
+  fetchErrorMessage = 'Failed to fetch library items',
+  deleteErrorMessage = 'Failed to delete item',
+}: UseSearchableLibraryOptions): UseSearchableLibraryReturn {
+  const [rawItems, setRawItems] = useState<LibraryItem[]>([]);
+  const { loading, error, run, execute } = useAsyncOperation(true);
+  const [searchQuery, setSearchQuery] = useState<string>('');
+
+  const fetchItems = useCallback(async (query: string) => {
+    try {
+      const results = await run(
+        () => query.trim() === '' ? libraryApi.getAll() : libraryApi.search(query),
+        fetchErrorMessage,
+      );
+      setRawItems(results);
+    } catch {
+      setRawItems([]);
+    }
+  }, [run, fetchErrorMessage]);
+
+  // Derive filtered items from raw items (no extra state or useEffect needed)
+  const items = useMemo(() => rawItems.filter(filter), [rawItems, filter]);
+
+  // Debounced search with leading: true so first call fires immediately (no double fetch)
+  const debouncedFetch = useDebouncedCallback(
+    (query: string) => fetchItems(query),
+    300,
+    { leading: true },
+  );
+
+  // Trigger fetch when search query changes (leading: true handles initial load)
+  useEffect(() => {
+    debouncedFetch(searchQuery);
+  }, [searchQuery, debouncedFetch]);
+
+  const deleteItem = useCallback(async (id: number): Promise<void> => {
+    await execute(
+      () => libraryApi.deleteItem(id),
+      deleteErrorMessage,
+    );
+    await fetchItems(searchQuery);
+  }, [execute, fetchItems, searchQuery, deleteErrorMessage]);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    await fetchItems(searchQuery);
+  }, [fetchItems, searchQuery]);
+
+  return {
+    items,
+    loading,
+    error,
+    searchQuery,
+    setSearchQuery,
+    deleteItem,
+    refresh,
+  };
+}

--- a/src/hooks/useSearchableLibrary.ts
+++ b/src/hooks/useSearchableLibrary.ts
@@ -4,7 +4,7 @@
  * (video library, script-only library, etc.).
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { libraryApi } from '@/lib/apiClient';
 import { useAsyncOperation } from '@/hooks/useAsyncOperation';
@@ -37,16 +37,22 @@ export function useSearchableLibrary({
   const [rawItems, setRawItems] = useState<LibraryItem[]>([]);
   const { loading, error, run, execute } = useAsyncOperation(true);
   const [searchQuery, setSearchQuery] = useState<string>('');
+  const requestIdRef = useRef(0);
 
   const fetchItems = useCallback(async (query: string) => {
+    const requestId = ++requestIdRef.current;
     try {
       const results = await run(
         () => query.trim() === '' ? libraryApi.getAll() : libraryApi.search(query),
         fetchErrorMessage,
       );
-      setRawItems(results);
+      if (requestId === requestIdRef.current) {
+        setRawItems(results);
+      }
     } catch {
-      setRawItems([]);
+      if (requestId === requestIdRef.current) {
+        setRawItems([]);
+      }
     }
   }, [run, fetchErrorMessage]);
 


### PR DESCRIPTION
## Summary

- Delete `useDemoLoop` — replace all callers with `useScriptLoop` + restart callback wrapped in `useCallback` to prevent stale closures (#54)
- Extract `useSearchableLibrary` base hook from `useLibrary`+`useScriptLibrary` with `useDebouncedCallback` (leading:true), `useMemo` for derived filtering, stable `deleteItem`/`refresh` refs (#55)
- Extract `useActionTransformer<TStats>` generic base hook from `useHumanizer`+`useSmoothing` with shared intensity/preview/commit lifecycle; extract `applyToRegion()` pure utility (#56)
- Extract `useDemoPlayback` from `usePatternEditor`+`useWaypointBuilder` encapsulating upload/start/loop/stop/error (#57)
- Replace manual 2s setTimeout in `useAutoSave` with `useDebouncedCallback` (#58)

## Test plan
- [ ] Verify pattern demo playback still works in pattern editor and waypoint builder
- [ ] Verify library search debounce works (type, pause, results appear)
- [ ] Verify humanizer and smoothing preview/commit/cancel cycle works
- [ ] Verify auto-save fires after 2s of inactivity
- [ ] Verify no double API calls on library page mount
- [ ] Run `npx tsc --noEmit` to confirm clean compilation

Closes #54, #55, #56, #57, #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added searchable library with debounced search, real-time filtering, item deletion, loading/error states, and manual refresh.

* **Refactor**
  * Improved playback loop behavior to explicitly restart/synchronize scripts when a loop ends for more reliable continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->