### PR TITLE
fix: duration input snaps back while typing multi-digit values

### DIFF
--- a/src/components/pattern-library/PatternEditorDialog.tsx
+++ b/src/components/pattern-library/PatternEditorDialog.tsx
@@ -179,9 +179,24 @@ export function PatternEditorDialog({
     }
   };
 
-  const handleDurationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = parseFloat(e.target.value);
-    if (!isNaN(value)) onDurationChange(value);
+  // Local string state prevents controlled-input snap-back while typing multi-digit values
+  const [durationInput, setDurationInput] = useState(() => (pattern?.durationMs ? (pattern.durationMs / 1000).toFixed(1) : ''));
+
+  // Sync local state when pattern changes externally (e.g., loading a different pattern)
+  useEffect(() => {
+    if (pattern?.durationMs !== undefined) {
+      setDurationInput((pattern.durationMs / 1000).toFixed(1));
+    }
+  }, [pattern?.durationMs]);
+
+  const commitDuration = () => {
+    const value = parseFloat(durationInput);
+    if (!isNaN(value) && value >= 0.5 && value <= 3600) {
+      onDurationChange(value);
+    } else {
+      // Reset to current valid value
+      setDurationInput((pattern!.durationMs / 1000).toFixed(1));
+    }
   };
 
   if (!isOpen || !pattern) return null;
@@ -229,9 +244,11 @@ export function PatternEditorDialog({
             type="number"
             step="0.1"
             min="0.5"
-            max="300"
-            value={(pattern.durationMs / 1000).toFixed(1)}
-            onChange={handleDurationChange}
+            max="3600"
+            value={durationInput}
+            onChange={(e) => setDurationInput(e.target.value)}
+            onBlur={commitDuration}
+            onKeyDown={(e) => { if (e.key === 'Enter') commitDuration(); }}
             className="w-full px-3 py-2 rounded bg-stone-800 border border-stone-700 text-white focus:outline-none focus:ring-2 focus:ring-amber-700/40"
           />
         </div>

--- a/src/components/pattern-library/PatternEditorDialog.tsx
+++ b/src/components/pattern-library/PatternEditorDialog.tsx
@@ -182,12 +182,12 @@ export function PatternEditorDialog({
   // Local string state prevents controlled-input snap-back while typing multi-digit values
   const [durationInput, setDurationInput] = useState(() => (pattern?.durationMs ? (pattern.durationMs / 1000).toFixed(1) : ''));
 
-  // Sync local state when pattern changes externally (e.g., loading a different pattern)
+  // Sync local state when pattern changes (including switching to a different pattern with same duration)
   useEffect(() => {
     if (pattern?.durationMs !== undefined) {
       setDurationInput((pattern.durationMs / 1000).toFixed(1));
     }
-  }, [pattern?.durationMs]);
+  }, [pattern?.id, pattern?.durationMs]);
 
   const commitDuration = () => {
     const value = parseFloat(durationInput);

--- a/src/components/pattern-library/RandomizerToolbar.tsx
+++ b/src/components/pattern-library/RandomizerToolbar.tsx
@@ -1,3 +1,5 @@
+import { useState, useEffect } from 'react';
+
 interface RandomizerToolbarProps {
   selectedCount: number;
   durationMinutes: number;
@@ -13,6 +15,21 @@ export function RandomizerToolbar({
   onGenerate,
   onCancel,
 }: RandomizerToolbarProps) {
+  const [durationInput, setDurationInput] = useState(() => String(durationMinutes));
+
+  useEffect(() => {
+    setDurationInput(String(durationMinutes));
+  }, [durationMinutes]);
+
+  const commitDuration = () => {
+    const val = parseInt(durationInput);
+    if (!isNaN(val) && val >= 1 && val <= 60) {
+      onDurationChange(val);
+    } else {
+      setDurationInput(String(durationMinutes));
+    }
+  };
+
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-stone-900 border-t border-stone-700 px-6 py-3 flex items-center justify-between z-50">
       <div className="flex items-center gap-4">
@@ -25,11 +42,10 @@ export function RandomizerToolbar({
             type="number"
             min={1}
             max={60}
-            value={durationMinutes}
-            onChange={(e) => {
-              const val = Math.max(1, Math.min(60, parseInt(e.target.value) || 1));
-              onDurationChange(val);
-            }}
+            value={durationInput}
+            onChange={(e) => setDurationInput(e.target.value)}
+            onBlur={commitDuration}
+            onKeyDown={(e) => { if (e.key === 'Enter') commitDuration(); }}
             className="w-16 px-2 py-1 rounded bg-stone-800 border border-stone-700 text-white text-sm focus:outline-none focus:ring-2 focus:ring-amber-700/40"
           />
           <span className="text-stone-400 text-sm">min</span>

--- a/src/hooks/usePatternEditor.ts
+++ b/src/hooks/usePatternEditor.ts
@@ -76,8 +76,8 @@ export function usePatternEditor() {
    * Changes pattern duration by scaling actions proportionally
    */
   const changeDuration = useCallback((newDurationSeconds: number) => {
-    // Validate bounds
-    if (newDurationSeconds < 0.5 || newDurationSeconds > 300) {
+    // Validate bounds (up to 1 hour)
+    if (newDurationSeconds < 0.5 || newDurationSeconds > 3600) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- Replace controlled number inputs with local string state + commit-on-blur/Enter pattern in `PatternEditorDialog` and `RandomizerToolbar`
- Raise duration cap from 300s to 3600s in `usePatternEditor.changeDuration`, `PatternEditorDialog.commitDuration`, and the HTML `max` attribute — patterns can already exceed 300s, so the old cap silently rejected valid edits

## Test plan
- [ ] Open pattern editor with a 600s pattern, type 500, blur — should accept
- [ ] Type invalid value (e.g., "abc"), blur — should reset to current value
- [ ] Randomizer toolbar duration input allows typing multi-digit values
- [ ] Verify Enter key also commits the value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duration fields now preserve what you type and only apply changes when you finish editing (on blur or Enter). Invalid entries revert to the current valid value.

* **New Features**
  * Increased maximum duration allowed across tools to 60 minutes and tightened validation to enforce acceptable ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->