### PR TITLE
fix: keep the device stopped when seeking a paused script

### DIFF
--- a/src/hooks/useScriptPlayback.ts
+++ b/src/hooks/useScriptPlayback.ts
@@ -178,7 +178,9 @@ export function useScriptPlayback({ ultra, scripts }: UseScriptPlaybackParams): 
       // new position is only recorded below. togglePause() resumes from
       // pausedAtRef, which puts the device at the seeked position.
       if (isPaused) {
-        await ultra.syncScriptStop();
+        // Already stopped when paused — this is a safety net, so a failure here
+        // must not discard a reposition that is otherwise purely local
+        try { await ultra.syncScriptStop(); } catch { /* already stopped */ }
       } else {
         await ultra.syncScriptStart(deviceTime);
       }

--- a/src/hooks/useScriptPlayback.ts
+++ b/src/hooks/useScriptPlayback.ts
@@ -173,11 +173,15 @@ export function useScriptPlayback({ ultra, scripts }: UseScriptPlaybackParams): 
     const deviceTime = Math.max(0, Math.round(warpedTarget));
 
     try {
-      // Stop the device first when paused so syncScriptStart doesn't resume playback
+      // The device has no reposition-without-play operation — syncScriptStart
+      // plays from the given time — so a paused session is left stopped and the
+      // new position is only recorded below. togglePause() resumes from
+      // pausedAtRef, which puts the device at the seeked position.
       if (isPaused) {
         await ultra.syncScriptStop();
+      } else {
+        await ultra.syncScriptStart(deviceTime);
       }
-      await ultra.syncScriptStart(deviceTime);
     } catch (err) {
       setPlaybackError(err instanceof Error ? err.message : 'Seek failed');
       return;


### PR DESCRIPTION
## What

`seek()` stopped the device and then called `syncScriptStart(deviceTime)` even while playback was paused, so dragging the timeline in a paused session set the device moving again while `isPaused`, the RAF clock and the position trackers all still read paused.

## Why

The Ultra SDK exposes no reposition-without-play operation — `syncScriptStart` PUTs `autoblow/sync-script/start` with `startTimeMs` and begins playback. The old comment on that branch assumed a preceding stop made the start behave as a seek; it does not.

## How

The paused branch now stops the device and records the new position locally only. `pausedAtRef` is assigned `deviceTime` immediately below, and `togglePause()` resumes from it, so the device lands at the seeked position when the user resumes.

This mirrors the same fix already applied to `reloadWarpedScript` in f521de2 (PR #84), which left `seek()` untouched because it predated that branch.

## Verification

- `npx tsc -b` clean
- `npx vitest run` — 187/187 pass

Device behaviour while paused needs a manual check on hardware: pause, drag the timeline, confirm the device stays still, then resume and confirm it picks up at the dragged position.