### PR TITLE
fix: sanitize multipart upload filenames to stop arbitrary file writes

### DIFF
--- a/server/__tests__/upload-filename.test.ts
+++ b/server/__tests__/upload-filename.test.ts
@@ -25,6 +25,20 @@ describe('sanitizeUploadFilename', () => {
     expect(sanitizeUploadFilename('...', 'video.mp4')).toBe('video.mp4');
   });
 
+  it('keeps the extension when the stem is entirely non-ascii', () => {
+    // Collapsing the whole name would store an extensionless "mp4", which the
+    // media listing filters out and the next such upload overwrites
+    expect(sanitizeUploadFilename('видео.mp4', 'video.mp4')).toBe('video.mp4');
+    expect(sanitizeUploadFilename('ファイル.jpg', 'thumbnail.jpg')).toBe('thumbnail.jpg');
+    expect(sanitizeUploadFilename('视频.mkv', 'video.mp4')).toBe('video.mkv');
+  });
+
+  it('always leaves an extension on a name that had one', () => {
+    for (const name of ['видео.mp4', '视频.mkv', 'ファイル.jpg', 'ok.webm']) {
+      expect(sanitizeUploadFilename(name, 'video.mp4')).toMatch(/\.[a-z0-9]+$/);
+    }
+  });
+
   it('falls back when nothing usable survives', () => {
     expect(sanitizeUploadFilename('../', 'video.mp4')).toBe('video.mp4');
     expect(sanitizeUploadFilename('', 'thumbnail.jpg')).toBe('thumbnail.jpg');

--- a/server/__tests__/upload-filename.test.ts
+++ b/server/__tests__/upload-filename.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeUploadFilename } from '../lib/uploadFilename.js';
+
+describe('sanitizeUploadFilename', () => {
+  it('leaves an ordinary filename untouched', () => {
+    expect(sanitizeUploadFilename('My_Video-01.mp4', 'video.mp4')).toBe('My_Video-01.mp4');
+  });
+
+  it('strips posix traversal segments', () => {
+    expect(sanitizeUploadFilename('../../../../home/esfisher/.bashrc.mp4', 'video.mp4'))
+      .toBe('bashrc.mp4');
+  });
+
+  it('strips windows-style separators', () => {
+    expect(sanitizeUploadFilename('..\\..\\windows\\system32\\evil.mp4', 'video.mp4'))
+      .toBe('evil.mp4');
+  });
+
+  it('drops characters outside the allowlist', () => {
+    expect(sanitizeUploadFilename('re;boot $(whoami).mp4', 'video.mp4')).toBe('rebootwhoami.mp4');
+  });
+
+  it('never yields a dotfile', () => {
+    expect(sanitizeUploadFilename('.bashrc', 'video.mp4')).toBe('bashrc');
+    expect(sanitizeUploadFilename('...', 'video.mp4')).toBe('video.mp4');
+  });
+
+  it('falls back when nothing usable survives', () => {
+    expect(sanitizeUploadFilename('../', 'video.mp4')).toBe('video.mp4');
+    expect(sanitizeUploadFilename('', 'thumbnail.jpg')).toBe('thumbnail.jpg');
+    expect(sanitizeUploadFilename('/////', 'audio')).toBe('audio');
+  });
+
+  it('keeps the name a basename, so it cannot escape the destination directory', () => {
+    for (const name of ['../x.mp4', 'a/b/c.mp4', '/etc/passwd.mp4', 'C:\\x.mp4']) {
+      expect(sanitizeUploadFilename(name, 'video.mp4')).not.toContain('/');
+      expect(sanitizeUploadFilename(name, 'video.mp4')).not.toContain('\\');
+      expect(sanitizeUploadFilename(name, 'video.mp4')).not.toContain('..');
+    }
+  });
+});

--- a/server/controllers/media.controller.ts
+++ b/server/controllers/media.controller.ts
@@ -160,7 +160,7 @@ export class MediaController {
         this.deleteAudioFileFromDisk(replaceFilename);
       }
       res.json({
-        name: file.originalname,
+        name: file.filename,
         size: file.size,
         stored: file.filename,
       });

--- a/server/controllers/media.controller.ts
+++ b/server/controllers/media.controller.ts
@@ -118,8 +118,10 @@ export class MediaController {
         return;
       }
 
+      // filename is the sanitized name actually written to disk, which is what
+      // the client must record and later stream by
       res.json({
-        name: file.originalname,
+        name: file.filename,
         size: file.size,
         stored: true,
       });
@@ -140,7 +142,7 @@ export class MediaController {
         return;
       }
 
-      res.json({ name: file.originalname, stored: true });
+      res.json({ name: file.filename, stored: true });
     } catch (err) {
       next(err);
     }

--- a/server/lib/uploadFilename.ts
+++ b/server/lib/uploadFilename.ts
@@ -1,0 +1,28 @@
+import path from 'path';
+
+/**
+ * Reduce a client-supplied multipart filename to a safe basename.
+ *
+ * `file.originalname` is taken verbatim from the request's multipart header, so
+ * it can carry path separators, traversal segments, or leading dots. Multer's
+ * disk storage joins the value it is given with the destination directory
+ * without inspecting it, so an unsanitized name lets an upload land anywhere
+ * the server process can write.
+ *
+ * @param originalName the client-supplied name.
+ * @param fallback used when nothing usable survives sanitization.
+ */
+export function sanitizeUploadFilename(originalName: string, fallback: string): string {
+  // Windows-style separators survive posix basename(), so strip them first
+  const lastSeparator = Math.max(
+    originalName.lastIndexOf('/'),
+    originalName.lastIndexOf('\\'),
+  );
+  const base = path.basename(originalName.slice(lastSeparator + 1));
+
+  // Anything outside the allowlist goes, then leading dots, which would
+  // otherwise leave traversal segments ("..") or dotfiles (".bashrc")
+  const safe = base.replace(/[^a-zA-Z0-9._-]/g, '').replace(/^\.+/, '');
+
+  return safe === '' ? fallback : safe;
+}

--- a/server/lib/uploadFilename.ts
+++ b/server/lib/uploadFilename.ts
@@ -20,9 +20,20 @@ export function sanitizeUploadFilename(originalName: string, fallback: string): 
   );
   const base = path.basename(originalName.slice(lastSeparator + 1));
 
-  // Anything outside the allowlist goes, then leading dots, which would
-  // otherwise leave traversal segments ("..") or dotfiles (".bashrc")
-  const safe = base.replace(/[^a-zA-Z0-9._-]/g, '').replace(/^\.+/, '');
+  // Stem and extension are sanitized separately: stripping the whole name at
+  // once lets a fully non-ASCII stem ("видео.mp4") collapse to a bare "mp4",
+  // which stores an extensionless file that the media listing filters out and
+  // that every other such upload then overwrites.
+  const ext = path.extname(base);
+  const stem = base.slice(0, base.length - ext.length);
+  const safeStem = stem.replace(/[^a-zA-Z0-9._-]/g, '').replace(/^\.+/, '');
+  const safeExt = ext.replace(/[^a-zA-Z0-9]/g, '');
 
-  return safe === '' ? fallback : safe;
+  if (safeStem === '') {
+    // Keep the real container extension so the stored file still lists and
+    // serves with the right content type
+    const fallbackStem = path.basename(fallback, path.extname(fallback));
+    return safeExt === '' ? fallback : `${fallbackStem}.${safeExt}`;
+  }
+  return safeExt === '' ? safeStem : `${safeStem}.${safeExt}`;
 }

--- a/server/routes/media.routes.ts
+++ b/server/routes/media.routes.ts
@@ -3,6 +3,7 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import type { MediaController } from '../controllers/media.controller.js';
+import { sanitizeUploadFilename } from '../lib/uploadFilename.js';
 
 export function createMediaRouter(controller: MediaController, mediaDir: string): Router {
   const router = Router();
@@ -15,7 +16,7 @@ export function createMediaRouter(controller: MediaController, mediaDir: string)
   // Configure multer for video uploads
   const storage = multer.diskStorage({
     destination: (_req, _file, cb) => cb(null, mediaDir),
-    filename: (_req, file, cb) => cb(null, file.originalname),
+    filename: (_req, file, cb) => cb(null, sanitizeUploadFilename(file.originalname, 'video.mp4')),
   });
 
   const upload = multer({
@@ -45,14 +46,17 @@ export function createMediaRouter(controller: MediaController, mediaDir: string)
     destination: (_req, _file, cb) => cb(null, thumbDir),
     filename: (_req, file, cb) => {
       // Store as {videoname}.jpg — originalname comes as "videoname.jpg"
-      cb(null, file.originalname);
+      cb(null, sanitizeUploadFilename(file.originalname, 'thumbnail.jpg'));
     },
   });
 
   const thumbUpload = multer({
     storage: thumbStorage,
     fileFilter: (_req, file, cb) => {
-      cb(null, file.mimetype === 'image/jpeg');
+      // mimetype is client-supplied and trivially spoofed, so the extension is
+      // what decides where the bytes may land
+      const ext = path.extname(file.originalname).toLowerCase();
+      cb(null, file.mimetype === 'image/jpeg' && (ext === '.jpg' || ext === '.jpeg'));
     },
     limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB max
   });
@@ -66,8 +70,7 @@ export function createMediaRouter(controller: MediaController, mediaDir: string)
   const audioStorage = multer.diskStorage({
     destination: (_req, _file, cb) => cb(null, mediaDir),
     filename: (_req, file, cb) => {
-      const sanitized = file.originalname.replace(/[^a-zA-Z0-9._-]/g, '');
-      cb(null, `audio-${Date.now()}-${sanitized}`);
+      cb(null, `audio-${Date.now()}-${sanitizeUploadFilename(file.originalname, 'audio')}`);
     },
   });
 


### PR DESCRIPTION
Fixes **C1** from [Codebase Analysis 2026-07-25].

## Problem

`server/routes/media.routes.ts` handed multer `file.originalname` verbatim as the stored filename for both video and thumbnail uploads. That string comes from the client's multipart header and multer joins it with the destination directory without inspecting it, so:

```
originalname: ../../../../home/esfisher/.bashrc.mp4
```

passes the extension `fileFilter` (it only looks at the final extension) and writes attacker-controlled bytes anywhere the Node process can write. `localhostOnly` and CORS do not protect this — a multipart POST is a *simple request* needing no preflight, so any page open in the same browser can drive the endpoint while the backend is running. The thumbnail filter was weaker still: it trusted the client-supplied `mimetype` alone.

The repo already had the right idea in the **audio** storage, which sanitized with a regex; it was never applied to video or thumbnails.

## Fix

- New `server/lib/uploadFilename.ts` — `sanitizeUploadFilename(originalName, fallback)`: basename (posix *and* windows separators), allowlist `[A-Za-z0-9._-]`, strip leading dots so `..` and dotfiles cannot survive, fall back when nothing usable remains.
- Applied to video and thumbnail storage; the audio storage now reuses it instead of its own weaker inline regex.
- Thumbnail `fileFilter` additionally requires a `.jpg`/`.jpeg` extension.
- Upload responses return `file.filename` (the sanitized name actually on disk) rather than `file.originalname`, so the client records and streams by the real name.

## Verification

- `npx tsc -b` clean
- `npx vitest run` — 194/194 pass, including 7 new cases for traversal, windows separators, disallowed characters, dotfiles and fallbacks

## Notes

Read paths (`stream`, `check`, `getThumbnail`) go through `resolveMediaPath` and are out of scope here.