### PR TITLE
fix: typecheck the server in npm run build and repair the errors that hid there

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev:frontend": "vite",
     "dev:backend": "tsx watch server/index.ts",
     "dev": "concurrently -n \"frontend,backend\" -c \"blue,green\" \"npm:dev:frontend\" \"npm:dev:backend\"",
-    "build": "tsc -b && vite build",
+    "typecheck": "tsc -b && tsc -p tsconfig.server.json",
+    "build": "npm run typecheck && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest"

--- a/server/__tests__/mod-generation.service.test.ts
+++ b/server/__tests__/mod-generation.service.test.ts
@@ -20,7 +20,7 @@ const VALID_DEFINITION: ScriptModDefinition = {
 
 /** Build a service whose Anthropic client resolves or rejects as instructed. */
 function makeService(behaviour: { resolve?: unknown; reject?: unknown }) {
-  const create = vi.fn(() =>
+  const create = vi.fn((..._args: unknown[]) =>
     behaviour.reject !== undefined
       ? Promise.reject(behaviour.reject)
       : Promise.resolve(behaviour.resolve),

--- a/server/__tests__/validation.test.ts
+++ b/server/__tests__/validation.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { parseIdParam } from '../middleware/validation.js';
+
+/** Minimal Express doubles — parseIdParam only reads params and writes a 400. */
+function makeReq(params: Record<string, unknown>): Request {
+  return { params } as unknown as Request;
+}
+
+function makeRes() {
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
+  return { res: { status } as unknown as Response, status, json };
+}
+
+describe('parseIdParam', () => {
+  it('parses a numeric route parameter', () => {
+    const { res, status } = makeRes();
+
+    expect(parseIdParam(makeReq({ id: '42' }), res)).toBe(42);
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('reads the named parameter when one is given', () => {
+    const { res } = makeRes();
+
+    expect(parseIdParam(makeReq({ itemId: '7' }), res, 'itemId')).toBe(7);
+  });
+
+  it('rejects a non-numeric value with a 400', () => {
+    const { res, status, json } = makeRes();
+
+    expect(parseIdParam(makeReq({ id: '12abc' }), res)).toBeNull();
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({ error: 'Invalid id parameter — must be a number' });
+  });
+
+  it('rejects a repeated route segment rather than coercing the array', () => {
+    const { res, status } = makeRes();
+
+    expect(parseIdParam(makeReq({ id: ['1', '2'] }), res)).toBeNull();
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a single-element array instead of unwrapping it to a number', () => {
+    // The one array shape that slipped through: RegExp.test stringifies
+    // ['5'] to "5", which matches, so the id silently parsed as 5
+    const { res, status } = makeRes();
+
+    expect(parseIdParam(makeReq({ id: ['5'] }), res)).toBeNull();
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a missing parameter', () => {
+    const { res, status } = makeRes();
+
+    expect(parseIdParam(makeReq({}), res)).toBeNull();
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects values the strict integer pattern does not allow', () => {
+    for (const raw of ['', ' 5', '5 ', '-1', '1.5', '0x10', '1e3', '+7']) {
+      const { res, status } = makeRes();
+
+      expect(parseIdParam(makeReq({ id: raw }), res)).toBeNull();
+      expect(status).toHaveBeenCalledWith(400);
+    }
+  });
+
+  it('names the offending parameter in the error', () => {
+    const { res, json } = makeRes();
+
+    parseIdParam(makeReq({ playlistId: 'nope' }), res, 'playlistId');
+
+    expect(json).toHaveBeenCalledWith({
+      error: 'Invalid playlistId parameter — must be a number',
+    });
+  });
+});

--- a/server/middleware/validation.ts
+++ b/server/middleware/validation.ts
@@ -23,8 +23,10 @@ export function requireStringQueryParam(
  * Returns the parsed number, or null if the response was already sent.
  */
 export function parseIdParam(req: Request, res: Response, paramName: string = 'id'): number | null {
+  // Express types a route param as `string | string[]`, and a repeated segment
+  // really can produce an array — reject anything that is not a plain string
   const raw = req.params[paramName];
-  if (!STRICT_INTEGER_RE.test(raw)) {
+  if (typeof raw !== 'string' || !STRICT_INTEGER_RE.test(raw)) {
     res.status(400).json({ error: `Invalid ${paramName} parameter — must be a number` });
     return null;
   }


### PR DESCRIPTION
Not from the analysis doc — found while verifying **C4**: `docker build .` **fails on `main` today**, so a `v*` tag would fail to publish.

## Problem

`tsconfig.json` references only `tsconfig.app.json` (`src`) and `tsconfig.node.json` (`vite.config.ts`). Nothing references `tsconfig.server.json` — the only thing that compiles it is the Dockerfile's backend stage:

```
RUN npx tsc --project tsconfig.server.json --outDir dist/server --noEmit false
```

So `tsc -b` and `npm run build` pass locally while `server/` carries type errors, and the first thing to notice is a failed image build during a release.

## Fix

- **package.json** — new `typecheck` script (`tsc -b && tsc -p tsconfig.server.json`); `build` runs it instead of bare `tsc -b`. Server type errors now fail the local build.
- **server/middleware/validation.ts** — `parseIdParam` fed `req.params[paramName]` (typed `string | string[]`, and a repeated route segment really can produce an array) directly to `STRICT_INTEGER_RE.test()`. It now rejects any non-string with the same 400 as a malformed id, which is also the correct runtime behaviour.
- **server/\_\_tests\_\_/mod-generation.service.test.ts** — the Anthropic client spy was `vi.fn(() => ...)`, which infers an empty argument tuple, so assertions indexing `mock.calls[n][0]` did not compile. The spy now declares `(..._args: unknown[])`.

## Verification

- `npm run typecheck` clean (both projects)
- `npx vitest run` — 187/187 pass
- `docker build .` **succeeds** (it fails on `main`)

## Merge order

Worth landing before #89 (single Docker deployment), which cannot get a green image build until this is in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request validation so invalid array-valued route parameters are rejected.
* **Tests**
  * Updated service test mocking to support flexible arguments while retaining configurable success and failure behavior.
* **Chores**
  * Added a dedicated type-checking command covering both frontend and server code.
  * Updated production builds to run all type checks before bundling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->